### PR TITLE
ias:Set the transparency of the wayland output(v3)

### DIFF
--- a/clients/wrandr.c
+++ b/clients/wrandr.c
@@ -421,13 +421,13 @@ set_transparency(struct wayland *wayland,
 	unsigned int output_num,
 	bool fb_transparency)
 {
-	struct crtc *crtc;
+	struct new_output *output;
 	unsigned int i = 1;
 
-	wl_list_for_each(crtc, &wayland->crtc_list, link) {
+	wl_list_for_each(output, &wayland->ias_output_list, link) {
 		if (output_num == i) {
 			printf("Set transparency to %d\n", fb_transparency);
-			ias_crtc_set_fb_transparency(crtc->ias_crtc, (int)fb_transparency);
+			ias_output_set_fb_transparency(output->ias_output, (int)fb_transparency);
 			return 0;
 		}
 		i++;

--- a/libweston/backend-classic.c
+++ b/libweston/backend-classic.c
@@ -299,7 +299,7 @@ init_output_classic(struct ias_output *ias_output,
 		while (attrs[0]) {
 			if (strcmp(attrs[0], "transparent") == 0) {
 				if ((sscanf(attrs[1], "%d",
-							&ias_crtc->transparency_enabled)) != 1) {
+							&ias_output->transparency_enabled)) != 1) {
 					IAS_ERROR("Badly formed transparent element: %s\n",
 							attrs[1]);
 				}

--- a/libweston/backend-flexible.c
+++ b/libweston/backend-flexible.c
@@ -319,7 +319,7 @@ init_output_flexible(struct ias_output *ias_output,
 				}
 			} else if (strcmp(attrs[0], "transparent") == 0) {
 				if ((sscanf(attrs[1], "%d",
-							&ias_crtc->transparency_enabled)) != 1) {
+							&ias_output->transparency_enabled)) != 1) {
 					IAS_ERROR("Badly formed transparent element: %s\n",
 							attrs[1]);
 				}

--- a/libweston/compositor-ias.c
+++ b/libweston/compositor-ias.c
@@ -862,21 +862,13 @@ ias_crtc_set_brightness(struct wl_client *client,
 }
 
 static void
-ias_crtc_set_fb_transparency(struct wl_client *client,
+ias_output_set_fb_transparency(struct wl_client *client,
 		struct wl_resource *resource,
 		uint32_t enabled)
 {
-	struct ias_crtc *ias_crtc = wl_resource_get_user_data(resource);
+	struct ias_output *ias_output = wl_resource_get_user_data(resource);
 
-	/*
-	 * Only set transparency when the output model has a  1 to 1
-	 * mapping between crtc and outputs.
-	 */
-	if (ias_crtc->num_outputs != 1) {
-		return;
-	}
-
-	ias_crtc->transparency_enabled = enabled;
+	ias_output->transparency_enabled = enabled;
 
 	return;
 }
@@ -965,7 +957,6 @@ struct ias_crtc_interface ias_crtc_implementation = {
 	ias_crtc_set_gamma,
 	ias_crtc_set_contrast,
 	ias_crtc_set_brightness,
-	ias_crtc_set_fb_transparency,
 };
 
 static int
@@ -1244,6 +1235,7 @@ struct ias_output_interface ias_output_implementation = {
 	ias_output_disable,
 	ias_output_enable,
 	ias_output_scale_to,
+	ias_output_set_fb_transparency,
 };
 
 static void
@@ -1351,7 +1343,7 @@ ias_fb_get_from_bo(struct gbm_bo *bo, struct weston_buffer *buffer,
 		/* if transparency is not enabled disable alpha channel only
 		 * when scanout == true, otherwise leave format unchanged
 		 */
-		if (fb_type == IAS_FB_SCANOUT && !ias_crtc->transparency_enabled &&
+		if (fb_type == IAS_FB_SCANOUT && !output->transparency_enabled &&
 		    format == GBM_FORMAT_ARGB8888) {
 			format = GBM_FORMAT_XRGB8888;
 		}

--- a/libweston/ias-backend.h
+++ b/libweston/ias-backend.h
@@ -283,7 +283,6 @@ struct ias_crtc {
 
 	int vblank_pending;
 	int page_flip_pending;
-	int transparency_enabled;
 	int request_set_mode;
 	int request_color_correction_reset;
 

--- a/libweston/ias-common.h
+++ b/libweston/ias-common.h
@@ -140,6 +140,7 @@ struct ias_output {
 	struct wl_signal update_signal;
 	struct wl_listener update_listener;
 	int is_resized;
+	int transparency_enabled;
 
 	int disabled;
 

--- a/protocol/ias-backend.xml
+++ b/protocol/ias-backend.xml
@@ -126,14 +126,6 @@
             <arg name="blue" type="uint" />
         </request>
 
-		<request name="set_fb_transparency">
-			<description summary="Set CRTC transparency">
-				Enables or disables transparency in the pixel format for the fb.
-			</description>
-
-			<arg name="enable" type="uint" />
-		</request>
-
     </interface>
 
     <interface name="ias_output" version="1">
@@ -179,6 +171,14 @@
             <arg name="width" type="uint" />
             <arg name="height" type="uint" />
         </request>
+
+		<request name="set_fb_transparency">
+			<description summary="Set Wayland output's transparency">
+				Enables or disables transparency in the pixel format for the fb.
+			</description>
+
+			<arg name="enable" type="uint" />
+		</request>
 
 		<event name="name">
 			<description summary="Output name">


### PR DESCRIPTION
Changes have been done such that the transaprecny of the planes
can be set individually.Earlier only the transparency of the crtc
could be set, which inturn was applicable to all the outputs.
Now this limitation is overcome and more granular control is provided.

v2:Additional code which is not required to resolve the issue is removed.
v3:Appropriate format for commiting the changes is followed.

Signed-off-by: Eligar, Guruprasad <guruprasad.eligar@intel.com>
Reviewed-by: Singh, Satyeshwar <satyeshwar.singh@intel.com>