### PR TITLE
ias.conf: Add eDP CRTC to default configuration

### DIFF
--- a/ias.conf.example
+++ b/ias.conf.example
@@ -6,6 +6,9 @@
 
   <backend raw_keyboards='1' use_nuclear_flip='1'>
     <startup>
+      <crtc name='eDP1' model='classic' mode='preferred'>
+        <output name='eDP1-0' size='inherit' position='origin' />
+      </crtc>
       <crtc name='HDMI1' model='classic' mode='preferred'>
         <output name='HDMI1-0' size='inherit' position='origin' />
       </crtc>


### PR DESCRIPTION
For certain platforms the eDP display takes precedence over HDMI
when both types are connected. This change makes IAS render on eDP by
default, and falls back to HDMI when eDP is not connected.

Signed-off-by: Tan, Yew Wayne <yew.wayne.tan@intel.com>