### PR TITLE
RemoteDisplay: Restored AVB transport plugin

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -686,6 +686,12 @@ transport_plugin_file_la_LIBADD =  $(LIBDRM_LIBS) $(SIMPLE_CLIENT_LIBS) libshare
 transport_plugin_file_la_CFLAGS = $(GCC_CFLAGS) $(COMPOSITOR_CFLAGS) $(LIBDRM_CFLAGS)
 transport_plugin_file_la_SOURCES = clients/RemoteDisplay/transport_plugin_file.c
 
+module_LTLIBRARIES += transport_plugin_avb.la
+transport_plugin_avb_la_LDFLAGS = -module -avoid-version
+transport_plugin_avb_la_LIBADD = $(LIBDRM_LIBS) $(SIMPLE_CLIENT_LIBS) libshared.la -lm -ldrm_intel -lgstreamer-1.0 -lgstbase-1.0 -lgstapp-1.0
+transport_plugin_avb_la_CFLAGS = $(GCC_CFLAGS) $(COMPOSITOR_CFLAGS) $(LIBDRM_CFLAGS) -I/usr/include/glib-2.0 -I/usr/include/gstreamer-1.0 -I/usr/lib/glib-2.0/include -I/usr/lib64/glib-2.0/include
+transport_plugin_avb_la_SOURCES = clients/RemoteDisplay/transport_plugin_avb.c
+
 module_LTLIBRARIES += transport_plugin_tcp.la
 transport_plugin_tcp_la_LDFLAGS = -module -avoid-version
 transport_plugin_tcp_la_LIBADD =  $(LIBDRM_LIBS) $(SIMPLE_CLIENT_LIBS) libshared.la -lm -ldrm_intel

--- a/clients/RemoteDisplay/transport_plugin_avb.c
+++ b/clients/RemoteDisplay/transport_plugin_avb.c
@@ -25,48 +25,28 @@
 /*
  * This file contains a transport plugin for the remote display wayland
  * client. This plugin uses the AVB StreamHandler to send the stream of
- * H264 frames over Ethernet. The plugin is responsible for breaking the
- * frames up into RTP packets and then passing them to the StreamHandler.
+ * H264 frames over Ethernet.
  */
 #include <stdio.h>
 #include <wayland-util.h>
 #include <libdrm/intel_bufmgr.h>
-#include <errno.h>
-#include <stdlib.h>
-#include <signal.h>
-#include <string.h>
-#include <netinet/in.h>
-#include <linux/limits.h>
 
-#include <media_transport/avb_ufipc_bridge/iasavbbridge.h>
+#include <gst/gst.h>
+#include <gst/app/gstappsrc.h>
 #include "../shared/config-parser.h"
 #include "../shared/helpers.h"
 
 #include "transport_plugin.h"
 
-
-#define RTP_BUFFER_SIZE 1400
-#define RTP_HEADER_SIZE (3*4)
-#define RTP_PAYLOAD_SIZE (RTP_BUFFER_SIZE - RTP_HEADER_SIZE)
-#define NAL_HEADER_SIZE 1
-#define FU_HEADER_SIZE 1
-#define FU_INDICATOR_SIZE 1
-#define NAL_MARKER_SIZE 3
-#define SPS_PPS_MARKER_SIZE 4
-#define NRI_MASK 0x60
-#define NAL_TYPE_MASK 0x1F
-#define FU_A_TYPE 28
-
-
 struct private_data {
 	int verbose;
 	int debug_packetisation;
-	ias_avbbridge_sender *sender;
 	char *avb_channel;
 	char *packet_path;
-	int to_ufipc;
 	int dump_packets;
 	FILE *packet_fp;
+	GstElement *pipeline;
+	GstElement *appsrc;
 };
 
 
@@ -75,6 +55,13 @@ WL_EXPORT int init(int *argc, char **argv, void **plugin_private_data,
 {
 	printf("Using avb remote display transport plugin...\n");
 	struct private_data *private_data = calloc(1, sizeof(*private_data));
+
+	GstElement *pipeline    = NULL;
+	GstElement *appsrc      = NULL;
+	GstElement *h264parse   = NULL;
+	GstElement *rtph264pay  = NULL;
+	GstElement *avbh264sink = NULL;
+
 	*plugin_private_data = (void *)private_data;
 	if (private_data) {
 		private_data->verbose = verbose;
@@ -84,7 +71,6 @@ WL_EXPORT int init(int *argc, char **argv, void **plugin_private_data,
 
 	const struct weston_option options[] = {
 		{ WESTON_OPTION_INTEGER, "debug_packets", 0, &private_data->debug_packetisation},
-		{ WESTON_OPTION_INTEGER, "ufipc", 0, &private_data->to_ufipc},
 		{ WESTON_OPTION_STRING,  "packet_path", 0, &private_data->packet_path},
 		{ WESTON_OPTION_INTEGER, "dump_packets", 0, &private_data->dump_packets},
 		{ WESTON_OPTION_STRING,  "channel", 0, &private_data->avb_channel},
@@ -121,23 +107,59 @@ WL_EXPORT int init(int *argc, char **argv, void **plugin_private_data,
 			return -1;
 		}
 		private_data->packet_path = tmp;
+
+		/*
+		 * branch gstreamer pipeline to dump RTP packets to a file
+		 * i.e.) appsrc ! h264parse ! rtph264pay ! tee name=t ! avbh264sink t. ! filesink location=packet_path
+		 */
 	}
 
-	if (private_data->to_ufipc) {
-		if (private_data->verbose) {
-			printf("Create AVB sender...\n");
-		}
-		private_data->sender = ias_avbbridge_create_sender(private_data->avb_channel);
-		if(!private_data->sender) {
-			fprintf(stderr, "Failed to create sender.\n");
-			free(private_data->packet_path);
-			free(private_data);
-			*plugin_private_data = NULL;
-			return -1;
-		}
+	if (private_data->verbose) {
+		printf("Create AVB sender...\n");
 	}
+
+	(void) gst_init (NULL, NULL);
+
+	pipeline   = gst_pipeline_new ("pipeline");
+	appsrc     = gst_element_factory_make ("appsrc", NULL);
+	h264parse  = gst_element_factory_make ("h264parse", NULL);
+	rtph264pay = gst_element_factory_make ("rtph264pay", NULL);
+	avbh264sink  = gst_element_factory_make ("avbh264sink", NULL);
+	if (!pipeline || !appsrc || !h264parse || !rtph264pay || !avbh264sink)
+		goto gst_free;
+
+	(void) g_object_set (G_OBJECT (avbh264sink), "skeleton-name", private_data->avb_channel, NULL);
+	(void) gst_bin_add_many(GST_BIN (pipeline), appsrc, h264parse, rtph264pay, avbh264sink, NULL);
+	if (!gst_element_link_many (appsrc, h264parse, rtph264pay, avbh264sink, NULL))
+		goto gst_free_pipeline;
+
+	if (gst_element_set_state (pipeline, GST_STATE_PLAYING) == GST_STATE_CHANGE_FAILURE)
+		goto gst_free_pipeline;
+
+	private_data->appsrc   = appsrc;
+	private_data->pipeline = pipeline;
 
 	return 0;
+
+gst_free:
+	if (appsrc)
+		gst_object_unref (GST_OBJECT (appsrc));
+	if (h264parse)
+		gst_object_unref (GST_OBJECT (h264parse));
+	if (rtph264pay)
+		gst_object_unref (GST_OBJECT (rtph264pay));
+	if (avbh264sink)
+		gst_object_unref (GST_OBJECT (avbh264sink));
+
+gst_free_pipeline:
+	if (pipeline) {
+		(void) gst_element_set_state (pipeline, GST_STATE_NULL);
+		(void) gst_object_unref (GST_OBJECT (pipeline));
+	}
+
+	fprintf(stderr, "Failed to create sender.\n");
+
+	return -1;
 }
 
 
@@ -153,375 +175,47 @@ WL_EXPORT void help(void)
 }
 
 
-/* This function assumes that we are allowed to overwrite the twelve bytes
- * that precede the incoming payload address. */
-static int
-send_packet(uint8_t *payload, size_t size, uint32_t timestamp,
-		int marker_bit, struct private_data *private_data)
-{
-	ias_avbbridge_buffer p;
-	uint8_t *rtpBase8 = (uint8_t *)(payload - RTP_HEADER_SIZE);
-	uint16_t *rtpBase16 = (uint16_t *)(payload - RTP_HEADER_SIZE);
-	uint32_t *rtpBase32 = (uint32_t *)(payload - RTP_HEADER_SIZE);
-	static uint16_t sequence_number = 1;
-
-	if (size > RTP_PAYLOAD_SIZE) {
-		fprintf(stderr, "Payload size %d too large (>1388).\n", (int)size);
-		return 1;
-	}
-
-	p.size = size + RTP_HEADER_SIZE;
-	p.data = rtpBase8;
-  if (private_data->debug_packetisation) {
-    printf("Sending packet of size %d...\n", (int)(p.size));
-  }
-
-	/* Fill packet using h.264 RTP style */
-	rtpBase8[0] = 0x80; /* RFC 1889 version(2) */
-	if (marker_bit) {
-		rtpBase8[1] = 0xE0; /* marker bit + payload type: hardcoded H264 */
-	} else {
-		rtpBase8[1] = 0x60; /* no marker bit + payload type: hardcoded H264 */
-	}
-
-	rtpBase32[1] = htonl(timestamp);
-	rtpBase32[2] = htonl(0x4120db95); /* SSRC hard-coded */
-	rtpBase16[1] = htons(sequence_number++);
-
-	if (!private_data) {
-		fprintf(stderr, "No private data!\n");
-		return -1;
-	}
-
-	/* Send packet over the wire... */
-	if (private_data->to_ufipc) {
-    int result = ias_avbbridge_send_packet_H264(private_data->sender, &p);
-		if (IAS_AVB_RES_OK != result) {
-			fprintf(stderr, "Failed to send packet: %d\n", result);
-			return 1;
-		}
-	}
-
-	/* Dump packet to file, using the same layout as gstreamer's RTP
-	 * stream file format... */
-	if (private_data->dump_packets) {
-		size_t count = 0;
-		uint16_t packet_size = (uint16_t)(p.size);
-
-		if (private_data->packet_fp == 0) {
-			printf("Opening packet output file: %s.\n", private_data->packet_path);
-			private_data->packet_fp = fopen(private_data->packet_path, "wb");
-			if (private_data->packet_fp == 0) {
-				fprintf(stderr, "Failed to open packet output file: %s.\n",
-					private_data->packet_path);
-				return 1;
-			}
-		}
-
-		/* Match the endianness of packet size expected by gstreamer... */
-		char* pstreamheader = (char *)(&packet_size);
-		count = fwrite((void *)(&pstreamheader[1]), sizeof(char), sizeof(char),
-			private_data->packet_fp);
-		if (count != sizeof(char)) {
-			fprintf(stderr, "Error writing header to file. Tried to write "
-					"%zu bytes, %zu bytes actually written.\n", sizeof(char),
-					count);
-		}
-		count = fwrite((void *)(&pstreamheader[0]), sizeof(char), sizeof(char),
-				private_data->packet_fp);
-		if (count != sizeof(char)) {
-			fprintf(stderr, "Error writing header to file. Tried to write "
-					"%zu bytes, %zu bytes actually written.\n", sizeof(char), count);
-		}
-
-		count = fwrite(p.data, sizeof(char), p.size, private_data->packet_fp);
-		if(count != p.size) {
-			fprintf(stderr, "Error dumping packet to file. Tried to write "
-					"%zu bytes, %zu bytes actually written.\n", p.size, count);
-		}
-	}
-
-	return 0;
-}
-
-
-static int
-get_ps_write_size(uint8_t *readptr)
-{
-	int i = 0;
-	int found_end = 0;
-
-	while (!found_end) {
-		if (readptr[i] == 0x00) {
-			if (readptr[i+1] == 0x00) {
-				if (readptr[i+2] == 0x00) {
-					if (readptr[i+3] == 0x01) {
-						found_end = 1;
-						continue;
-					}
-				} else if (readptr[i+2] == 0x01) {
-					found_end = 1;
-					continue;
-				}
-			}
-		}
-		i++;
-	}
-	return i;
-}
-
-
 WL_EXPORT int send_frame(void *plugin_private_data, drm_intel_bo *drm_bo,
 		int32_t stream_size, uint32_t timestamp)
 {
-	int num_packets = 0;
-	int bytes_written = 0;
-	uint16_t count = 0;
-	uint8_t rtp_buffer[RTP_BUFFER_SIZE];
-	uint8_t *rtp_payload = &rtp_buffer[RTP_HEADER_SIZE];
-	uint8_t *fu_start;
 	uint8_t *readptr = drm_bo->virtual;
-	int32_t write_size = stream_size;
-	uint8_t nal_header;
-	int start = 1, end = 0;
-	/* Allow for FU indicator size and FU header size */
-	const int step = RTP_PAYLOAD_SIZE - FU_HEADER_SIZE - FU_INDICATOR_SIZE;
-	int spspps = 0;
-	uint8_t *bufdata;
-	volatile sig_atomic_t send_packages;
-	int err = 0;
-
 	struct private_data *private_data = (struct private_data *)plugin_private_data;
+
+	GstBuffer *gstbuf = NULL;
+	GstMapInfo gstmap;
 
 	if (!private_data) {
 		fprintf(stderr, "No private data!\n");
-		return -1;
+		goto error;
 	}
 
 	if (private_data->verbose) {
 		printf("Sending frame over AVB...\n");
 	}
 
-	/* SPS and PPS are preceded by the bytes 00 00 00 01 (in our case).
-	 * 00 00 01 means we have an ordinary NAL unit containing an h264
-	 * encoded frame. This may well be different and more nuanced with
-	 * other implementations. */
-	bufdata = ((uint8_t *)(drm_bo->virtual));
-	if (bufdata[0] == 0x00) {
-		if (bufdata[1] == 0x00) {
-			if (bufdata[2] == 0x00) {
-				if (bufdata[3] == 0x01) {
-					/* SPS or PPS */
-					if (private_data->debug_packetisation) {
-						printf("SPS or PPS frame\n");
-					}
-					spspps = 1;
-				} else {
-					fprintf(stderr, "Invalid start of stream.\n");
-					return 1;
-				}
-			} else if (bufdata[2] == 0x01) {
-				/* Ordinary NAL unit containing an h264 encoded frame */
-				if (private_data->debug_packetisation) {
-					printf("00 00 01 - start of frame?\n");
-				}
-			} else {
-				fprintf(stderr, "Invalid frame.\n");
-				return 1;
-			}
-		}
-	}
+	gstbuf = gst_buffer_new_and_alloc (stream_size);
+	if (!readptr || !gstbuf)
+		goto error;
 
-	send_packages = 1;
-	while (send_packages){
-		num_packets++;
-		if (spspps == 1) {
-			int32_t sps_size, pps_size;
-			/* Skip 00 00 00 01 */
-			readptr += SPS_PPS_MARKER_SIZE;
-			sps_size = get_ps_write_size(readptr);
+	if (!gst_buffer_map (gstbuf, &gstmap, GST_MAP_WRITE))
+		goto error;
 
-			if (private_data->debug_packetisation) {
-				nal_header = readptr[0];
-				printf("Skipping 00 00 00 01 marker and writing %d "
-					"bytes + 12 byte header\n", sps_size);
-				printf("SPS - nal_type = 0x%x\n",
-					nal_header & NAL_TYPE_MASK);
-			}
-			/* Send SPS... */
-			memcpy(rtp_payload, readptr, sps_size);
-			err = send_packet(rtp_payload, sps_size, timestamp, 1,
-					private_data);
-			bytes_written += sps_size;
-			if (err) {
-				fprintf(stderr, "Warning: Sending SPS packet returned %d.\n",
-						err);
-				err = 0;
-			}
+	(void) memcpy (gstmap.data, readptr, stream_size);
 
-			/* Advance readptr by SPS + second 00 00 00 01 marker... */
-			readptr += sps_size + SPS_PPS_MARKER_SIZE;
-			pps_size = get_ps_write_size(readptr);
+	(void) gst_buffer_unmap(gstbuf, &gstmap);
 
-			if (private_data->debug_packetisation) {
-				printf("Skipping second 00 00 00 01 marker and writing"
-				   " %d bytes + 12 byte header\n", pps_size);
-				nal_header = readptr[0];
-				printf("PPS - nal_type = 0x%x\n",
-					nal_header & NAL_TYPE_MASK);
-			}
+	if (gst_app_src_push_buffer (GST_APP_SRC (private_data->appsrc), gstbuf) != GST_FLOW_OK)
+		goto error;
 
-			/* Send PPS... */
-			/* We avoid doing a memcpy where possible, writing
-			 * the headers to the mapped buffer instead. (This
-			 * trashes the previous 12 bytes in the buffer, but we
-			 * don't need to worry about that.) */
-			if (bytes_written >= RTP_HEADER_SIZE) {
-				err = send_packet(readptr, pps_size, timestamp,
-					1, private_data);
-			} else {
-				memcpy(rtp_payload, readptr, pps_size);
-				err = send_packet(rtp_payload, pps_size, timestamp, 1,
-						private_data);
-			}
-			bytes_written += pps_size;
-			if (err) {
-				fprintf(stderr, "Warning: Sending PPS packet returned %d.\n",
-						err);
-				err = 0;
-			}
-
-			/* There will be a NAL unit in buffer after SPS and PPS. */
-			readptr += pps_size;
-			write_size = stream_size -
-				(sps_size + pps_size + 2 * SPS_PPS_MARKER_SIZE);
-			spspps = 0;
-		}
-
-		if (start == 1) {
-			/* Skip 00 00 01 marker before NAL unit starts... */
-			readptr += NAL_MARKER_SIZE;
-			write_size -= NAL_MARKER_SIZE;
-			nal_header = readptr[0];
-			if (private_data->debug_packetisation) {
-				printf("Skipped 00 00 01 marker.\n");
-				printf("nal_type = 0x%x\n",
-					nal_header & NAL_TYPE_MASK);
-			}
-		}
-
-		/* NAL packetisation into Fragmentation Units (FUs)...*/
-		if (RTP_PAYLOAD_SIZE >= write_size) {
-			/* Stream is smaller than a packet, no FUs. */
-			if (private_data->debug_packetisation) {
-				printf("Small packet, only writing %d bytes.\n", write_size);
-			}
-			if (bytes_written >= RTP_HEADER_SIZE) {
-				err = send_packet(readptr, write_size, timestamp,
-					1, private_data);
-			} else {
-				memcpy(rtp_payload, readptr, write_size);
-				err = send_packet(rtp_payload, write_size, timestamp, 1,
-						private_data);
-			}
-			bytes_written += write_size;
-			if (err) {
-				fprintf(stderr, "Warning: Sending small packet returned %d.\n",
-						err);
-				err = 0;
-			}
-			send_packages = 0;
-		} else if (step * count < write_size) {
-			count++;
-
-			/* FU indicator - as per section 5.8 of rfc6184. */
-			*rtp_payload = (nal_header & NRI_MASK) | FU_A_TYPE;
-
-			/* FU header - as per section 5.8 of rfc6184. */
-			*(rtp_payload + 1) = (start << 7) | (end << 6) |
-				(nal_header & NAL_TYPE_MASK);
-
-			if (private_data->debug_packetisation) {
-				printf("%s FU. Indicator 0x%x Header 0x%x\n",
-					start ? "First" : "Middle",
-					/* Sometimes fprintf tries to interpret
-					 * these as 64-bit ints. The 0xFF & fixes that. */
-					0xFF & *rtp_payload, 0xFF & *(rtp_payload + 1));
-			}
-
-			if (start) {
-				/* Skip the NAL header because the info is
-				 * already in the FU indicator and header. */
-				readptr += NAL_HEADER_SIZE;
-				start = 0;
-			}
-
-			if (bytes_written >= RTP_HEADER_SIZE) {
-				/* We have the marker bits free as well as the header size. */
-				fu_start = readptr - FU_HEADER_SIZE - FU_INDICATOR_SIZE;
-				fu_start[0] = *rtp_payload;
-				fu_start[1] = *(rtp_payload + 1);
-				err = send_packet(fu_start, RTP_PAYLOAD_SIZE,
-					timestamp, 0, private_data);
-			} else {
-				memcpy(rtp_payload + FU_HEADER_SIZE + FU_INDICATOR_SIZE,
-					readptr, step);
-				err = send_packet(rtp_payload, RTP_PAYLOAD_SIZE,
-					timestamp, 0, private_data);
-			}
-			bytes_written += step;
-			if (err) {
-				fprintf(stderr, "Warning: Sending FU packet returned %d.\n",
-						err);
-				err = 0;
-			}
-
-			readptr += step;
-		} else {
-			/* Last FU... */
-			int bytes_left = write_size - (step*(count-1)) - NAL_HEADER_SIZE;
-
-			end = 1;
-			*rtp_payload = (nal_header & NRI_MASK) | FU_A_TYPE;
-			*(rtp_payload + 1) = (start << 7) | (end << 6) |
-						(nal_header & NAL_TYPE_MASK);
-
-			if (private_data->debug_packetisation) {
-				printf("Last FU. Indicator: 0x%x, Header: 0x%x, size: %d\n",
-					*rtp_payload, *(rtp_payload + 1), bytes_left);
-			}
-
-			if (bytes_written >= RTP_HEADER_SIZE) {
-				/* We have the marker bits free as well as the header size. */
-				fu_start = readptr - FU_HEADER_SIZE - FU_INDICATOR_SIZE;
-				fu_start[0] = *rtp_payload;
-				fu_start[1] = *(rtp_payload + 1);
-				err = send_packet(fu_start, bytes_left
-					+ FU_HEADER_SIZE + FU_INDICATOR_SIZE,
-					timestamp, 1, private_data);
-			} else {
-				memcpy(rtp_payload + FU_HEADER_SIZE
-					+ FU_INDICATOR_SIZE,
-					readptr, bytes_left);
-				err = send_packet(rtp_payload, bytes_left
-					+ FU_HEADER_SIZE + FU_INDICATOR_SIZE,
-					timestamp, 1, private_data);
-			}
-			bytes_written += bytes_left;
-			if (err) {
-				fprintf(stderr, "Warning: Sending final packet returned %d.\n",
-						err);
-				err = 0;
-			}
-
-			send_packages = 0;
-		}
-	}
-
-	if (private_data->verbose || private_data->debug_packetisation) {
-		printf("Packets for frame = %d packets.\n", num_packets);
-	}
 	return 0;
+
+error:
+	fprintf(stderr, "Send failed.\n");
+
+	if (gstbuf)
+		gst_buffer_unref (gstbuf);
+
+	return -1;
 }
 
 
@@ -533,8 +227,9 @@ WL_EXPORT void destroy(void **plugin_private_data)
 		return;
 	}
 
-	if (private_data->packet_fp) {
-		ias_avbbridge_destroy_sender(private_data->sender);
+	if (private_data->pipeline) {
+		(void) gst_element_set_state (private_data->pipeline, GST_STATE_NULL);
+		(void) gst_object_unref (GST_OBJECT (private_data->pipeline));
 	}
 
 	if (private_data->packet_fp) {

--- a/configure.ac
+++ b/configure.ac
@@ -410,6 +410,7 @@ if test x$enable_remote_display != xno; then
   fi
   AS_IF([test "x$have_libva" = "xyes" -a "x$enable_frame_capture" = "xyes"],
         [AC_DEFINE([BUILD_REMOTE_DISPLAY], [1], [Build remote display])])
+  PKG_CHECK_MODULES(GSTREAMER, [gstreamer-1.0 gstreamer-plugins-base-1.0])
 fi
 AM_CONDITIONAL(ENABLE_REMOTE_DISPLAY, test "x$have_libva" = "xyes" -a "x$enable_frame_capture" = "xyes")
 


### PR DESCRIPTION
The new AVB plugin transmits H.264 frames through avbh264sink
gstreamer element. It requires gstreamer-1.0 and gst-plugins-base
packages for compilation as well as for runtime.

Signed-off-by: Toshiki Nishioka <toshiki.nishioka@intel.com>