### PR TITLE
Modifying qp to suit streaming

### DIFF
--- a/clients/RemoteDisplay/encoder.c
+++ b/clients/RemoteDisplay/encoder.c
@@ -618,7 +618,7 @@ encoder_init_pic_parameters(struct rd_encoder * const encoder)
 		return;
 	}
 
-	pic_param->pic_init_qp = 0;
+	pic_param->pic_init_qp = 24;
 
 	/* Entropy mode is either CAVLC (0) or CABAC */
 	pic_param->pic_fields.bits.entropy_coding_mode_flag = 1;


### PR DESCRIPTION
Right quantization parameter is required to suit any practical use-cases.
Modifying that to have constant quality and suit wired streaming scenarios.