### PR TITLE
Modifying qp to suit wired streaming

### DIFF
--- a/clients/RemoteDisplay/encoder.c
+++ b/clients/RemoteDisplay/encoder.c
@@ -117,6 +117,7 @@ struct rd_encoder {
 	} region;
 	int profile_level;
 	int encoder_tu;
+	int qp;
 
 	uint16_t frame_count;
 	int num_vsyncs;
@@ -618,7 +619,7 @@ encoder_init_pic_parameters(struct rd_encoder * const encoder)
 		return;
 	}
 
-	pic_param->pic_init_qp = 0;
+	pic_param->pic_init_qp = encoder->qp;
 
 	/* Entropy mode is either CAVLC (0) or CABAC */
 	pic_param->pic_fields.bits.entropy_coding_mode_flag = 1;
@@ -1918,7 +1919,8 @@ rd_encoder_init(struct rd_encoder * const encoder,
 				const int w, const int h,
 				const int encoder_tu,
 				uint32_t surfid, struct ias_hmi * const hmi,
-				struct wl_display *display, uint32_t output_number)
+				struct wl_display *display, uint32_t output_number,
+				const int encoder_qp)
 {
 	int err;
 
@@ -1935,6 +1937,7 @@ rd_encoder_init(struct rd_encoder * const encoder,
 	encoder->region.w = w;
 	encoder->region.h = h;
 	encoder->encoder_tu = encoder_tu;
+	encoder->qp = encoder_qp;
 	encoder->surfid = surfid;
 	encoder->hmi = hmi;
 	encoder->display = display;

--- a/clients/RemoteDisplay/encoder.h
+++ b/clients/RemoteDisplay/encoder.h
@@ -51,7 +51,7 @@ rd_encoder_init(struct rd_encoder * const encoder,
 				const int encoder_tu,
 				uint32_t surfid, struct ias_hmi * const hmi,
 				struct wl_display *display,
-				uint32_t output_number);
+				uint32_t output_number, const int encoder_qp);
 void
 rd_encoder_destroy(struct rd_encoder *encoder);
 int

--- a/clients/RemoteDisplay/main.c
+++ b/clients/RemoteDisplay/main.c
@@ -173,7 +173,8 @@ encoder_init_thread_function(void * const data)
 				app_state->encoder_tu,
 				app_state->surfid, app_state->hmi,
 				app_state->display,
-				app_state->output_number);
+				app_state->output_number,
+				app_state->encoder_qp);
 
 	if (err == 0) {
 		app_state->encoder_state = ENC_STATE_RUN;
@@ -733,9 +734,11 @@ main(int argc, char **argv)
 		{ WESTON_OPTION_INTEGER, "w", 0, &app_state.w},
 		{ WESTON_OPTION_INTEGER, "h", 0, &app_state.h},
 		{ WESTON_OPTION_INTEGER, "tu", 0, &app_state.encoder_tu},
+		{ WESTON_OPTION_INTEGER, "qp", 0, &app_state.encoder_qp},
 		{ WESTON_OPTION_BOOLEAN, "help", 0, &help },
 	};
 
+	app_state.encoder_qp = -1;
 	parse_options(options, ARRAY_LENGTH(options), &argc, argv);
 
 	if (help) {
@@ -765,6 +768,15 @@ main(int argc, char **argv)
 	if (app_state.encoder_tu == 0) {
 		/* Default to fastest encode mode. */
 		app_state.encoder_tu = 7;
+	}
+
+	/* Setting to default 24 if unspecified*/
+	if (app_state.encoder_qp < 0) {
+		app_state.encoder_qp = 24;
+	}
+	/* Clipping to table values */
+	if (app_state.encoder_qp > 51) {
+		app_state.encoder_qp = 51;
 	}
 
 	err = init(&app_state, &argc, argv);

--- a/clients/RemoteDisplay/main.h
+++ b/clients/RemoteDisplay/main.h
@@ -51,6 +51,7 @@ struct app_state {
 	int w;
 	int h;
 	int encoder_tu;
+	int encoder_qp;
 	int output_number;
 	int output_origin_x;
 	int output_origin_y;


### PR DESCRIPTION
---

Description: Any encoding scenario deals with variable quality with
constant bitrate or variable bitrate with constant quality. Remote display
is a streaming application to be used under wired local gigabit network.
Under such environment, constant quality is preferred. For H264, constant
quality of 24 QP, is practically undistinguishable from original, so setting
QP to 24.