### PR TITLE
mediaplayer : adding missed gst libs for compilation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1072,7 +1072,8 @@ mediaplayer_CFLAGS = $(AM_CFLAGS) $(SIMPLE_CLIENT_CFLAGS) -I/usr/include/glib-2.
 			-I/usr/include/gstreamer-1.0 -I/usr/lib/glib-2.0/include \
 			-I/usr/lib64/glib-2.0/include
 mediaplayer_LDADD = $(LIBDRM_LIBS) $(SIMPLE_CLIENT_LIBS) libshared.la -lm -lpthread \
-			-lgstreamer-1.0 -lgstbase-1.0 -lgstapp-1.0 -lgstvideo-1.0
+			-lgstreamer-1.0 -lgstbase-1.0 -lgstapp-1.0 -lgstvideo-1.0 \
+			-lgobject-2.0 -lglib-2.0
 
 weston_clock_CFLAGS = $(AM_CFLAGS) $(CLIENT_CFLAGS)
 


### PR DESCRIPTION
Compilation error is caused by some missed gst libs.
Added gobject-2.0 and glib-2.0 into Makefile.am.

Signed-off-by: Chae, Alex <alex.chae@intel.com>