### PR TITLE
Fix segfault

### DIFF
--- a/clients/vmdisplay/vmdisplay-server-hyperdmabuf.cpp
+++ b/clients/vmdisplay/vmdisplay-server-hyperdmabuf.cpp
@@ -141,13 +141,13 @@ int HyperDMABUFCommunicator::recv_metadata(void **buffer)
 			last_counter = -1;
 		}
 
-		len = recv_data(metadata,
-				sizeof(struct vm_header) +
-				sizeof(struct vm_buffer_info) +
-				sizeof(struct hyper_dmabuf_event_hdr));
+		do {
+			len = recv_data(metadata,
+					sizeof(struct vm_header) +
+					sizeof(struct vm_buffer_info) +
+					sizeof(struct hyper_dmabuf_event_hdr));
 
-		if (len < 0)
-			continue;
+		} while(len < 0)
 
 		event_hdr = (struct hyper_dmabuf_event_hdr *)&metadata[0];
 
@@ -184,7 +184,7 @@ int HyperDMABUFCommunicator::recv_metadata(void **buffer)
 			 * all buffers for current frame, send out new frame metadata to clients.
 			 */
 			if (hdr->counter != last_counter ||
-			    num_buffers == hdr->n_buffers) {
+			    num_buffers >= hdr->n_buffers) {
 				last_hdr.n_buffers = num_buffers;
 				memcpy(buffer[last_hdr.output],
 				       &last_hdr, sizeof(struct vm_header));

--- a/clients/vmdisplay/vmdisplay-server.cpp
+++ b/clients/vmdisplay/vmdisplay-server.cpp
@@ -290,11 +290,9 @@ int VMDisplayServer::init(int domid,
 
 int VMDisplayServer::cleanup()
 {
-	if (running) {
-		pthread_join(metadata_thread, NULL);
-		pthread_join(input_thread, NULL);
-		pthread_mutex_destroy(&mutex);
-	}
+	pthread_join(metadata_thread, NULL);
+	pthread_join(input_thread, NULL);
+	pthread_mutex_destroy(&mutex);
 
 	if (hyper_comm_metadata) {
 		hyper_comm_metadata->cleanup();


### PR DESCRIPTION
there are 2 segfault issue:
1.  while rebooting android as Acrn Guest, the vmdisplay-server will crash as segmentation fault. Same as stop/start surfaceflinger/hwcomposer. 

2. just terminal the vmdisplay-server via 'ctrl+c'

Above are fix patch.

Will send another proposal patch of another implementation of recv_metadata()