### PR TITLE
vmdisplay: fix segfault in server exit with SIGINT

### DIFF
--- a/clients/vmdisplay/vmdisplay-server.cpp
+++ b/clients/vmdisplay/vmdisplay-server.cpp
@@ -290,11 +290,9 @@ int VMDisplayServer::init(int domid,
 
 int VMDisplayServer::cleanup()
 {
-	if (running) {
-		pthread_join(metadata_thread, NULL);
-		pthread_join(input_thread, NULL);
-		pthread_mutex_destroy(&mutex);
-	}
+	pthread_join(metadata_thread, NULL);
+	pthread_join(input_thread, NULL);
+	pthread_mutex_destroy(&mutex);
 
 	if (hyper_comm_metadata) {
 		hyper_comm_metadata->cleanup();


### PR DESCRIPTION
main thread exited before other communication threads and cuased this
segmentation fault. It's not safe to use the global variable 'running' to
control the lifecycle alone.

Fix: https://github.com/intel/ias/issues/34

Signed-off-by: Xinyun Liu <xinyun.liu@intel.com>