### PR TITLE
Fixed the vmdisplay-server crash when demux data from multiple Guest clients

### DIFF
--- a/clients/vmdisplay/vmdisplay-server-hyperdmabuf.cpp
+++ b/clients/vmdisplay/vmdisplay-server-hyperdmabuf.cpp
@@ -62,7 +62,14 @@ int HyperDMABUFCommunicator::init(int domid,
 
 	hdr = NULL;
 	buf_info = NULL;
-	last_counter = -1;
+
+	int j;
+
+	for (j = 0; j < VM_MAX_OUTPUTS; j++)
+		last_counter[j] = -1;
+
+	for (j=0; j<VM_MAX_OUTPUTS; j++)
+		num_buffers[j] = 0;
 
 	/* Leave space at the begining of buffers for header */
 	for (int i = 0; i < VM_MAX_OUTPUTS; i++)
@@ -117,8 +124,6 @@ int HyperDMABUFCommunicator::recv_metadata(void **buffer)
 {
 	int len;
 
-	struct vm_header last_hdr;
-	int num_buffers = 0;
 	struct hyper_dmabuf_event_hdr *event_hdr;
 
 	while (1) {
@@ -126,19 +131,19 @@ int HyperDMABUFCommunicator::recv_metadata(void **buffer)
 		 * In case when we received alreay buffer for next frame,
 		 * append its metadata to new frame metadata.
 		 */
-		if (hdr)
-			memcpy(&last_hdr, hdr, sizeof(*hdr));
 
-		if (hdr && hdr->counter != last_counter) {
+		if (hdr && hdr->counter != last_counter[hdr->output]) {
 			/* Copy metatadat to mmaped file of given output */
 			memcpy((char *)buffer[hdr->output] +
-			       offset[hdr->output], buf_info,
-			       sizeof(struct vm_buffer_info));
-			offset[hdr->output] += sizeof(struct vm_buffer_info);
-			num_buffers++;
-			last_counter = hdr->counter;
+					offset[hdr->output], buf_info,
+					sizeof(struct vm_buffer_info));
+                      offset[hdr->output] += sizeof(struct vm_buffer_info);
+		      num_buffers[hdr->output]++;
+		      last_counter[hdr->output] = hdr->counter;
 		} else {
-			last_counter = -1;
+			if (hdr) {
+				last_counter[hdr->output] = -1;
+			}
 		}
 
 		do {
@@ -168,32 +173,28 @@ int HyperDMABUFCommunicator::recv_metadata(void **buffer)
 			 * Check if we received buffer from the same frame,
 			 * if so, append its metadata to frame metadata.
 			 */
-			if (last_counter == -1 || hdr->counter == last_counter) {
+			if (last_counter[hdr->output] == -1 || hdr->counter == last_counter[hdr->output]) {
 				/* Copy metatadat to mmaped file of given output */
 				memcpy((char *)buffer[hdr->output] +
 				       offset[hdr->output], buf_info,
 				       sizeof(struct vm_buffer_info));
 				offset[hdr->output] +=
 				    sizeof(struct vm_buffer_info);
-				num_buffers++;
-				last_counter = hdr->counter;
+				num_buffers[hdr->output]++;
+				last_counter[hdr->output] = hdr->counter;
 			}
 
 			/*
 			 * In case that we received buffer for new frame, or we received
 			 * all buffers for current frame, send out new frame metadata to clients.
 			 */
-			if (hdr->counter != last_counter ||
-			    num_buffers >= hdr->n_buffers) {
-				last_hdr.n_buffers = num_buffers;
-				memcpy(buffer[last_hdr.output],
-				       &last_hdr, sizeof(struct vm_header));
-
-				num_buffers = 0;
-				offset[last_hdr.output] =
-				    sizeof(struct vm_header);
-
-				return last_hdr.output;
+			if (hdr->counter != last_counter[hdr->output] ||
+			    num_buffers[hdr->output] >= hdr->n_buffers) {
+				memcpy(buffer[hdr->output], hdr, sizeof(struct vm_header));
+				num_buffers[hdr->output] = 0;
+				offset[hdr->output] =
+					sizeof(struct vm_header);
+				return hdr->output;
 			}
 
 		}

--- a/clients/vmdisplay/vmdisplay-server-hyperdmabuf.h
+++ b/clients/vmdisplay/vmdisplay-server-hyperdmabuf.h
@@ -52,7 +52,8 @@ private:
 	struct vm_header *hdr;
 	struct vm_buffer_info *buf_info;
 	int offset[VM_MAX_OUTPUTS];
-	int last_counter;
+	int last_counter[VM_MAX_OUTPUTS];
+	int num_buffers[VM_MAX_OUTPUTS];
 };
 
 #endif // _VMDISPLAY_SERVER_HYPERDMABUF_H_


### PR DESCRIPTION
The data from Guest hyper dmabuf channels sometime is interleaved. This caused
broken display meta data. The consequence of it is vmdisplay-server may crash
or content of display parsered incorrectly.

The fix is to use array to track each channels meta data separately to avoid
meta data corruption.

Signed-off-by: Wan Shuang <shuang.wan@intel.com>