### PR TITLE
vmdisplay: Fixed an error with wl_drm versioning.

### DIFF
--- a/clients/vmdisplay/vmdisplay-wayland.c
+++ b/clients/vmdisplay/vmdisplay-wayland.c
@@ -1083,12 +1083,12 @@ registry_handle_global(void *data, struct wl_registry *registry, uint32_t name,
 		ias_hmi_add_listener(d->hmi, &hmi_listener, d);
 	} else if (strcmp(interface, "wl_drm") == 0) {
 		d->wl_drm =
-		    wl_registry_bind(registry, name, &wl_drm_interface, 3);
+		    wl_registry_bind(registry, name, &wl_drm_interface, 2);
 		wl_drm = d->wl_drm;
 	} else if (strcmp(interface, "zwp_linux_dmabuf_v1") == 0) {
 		d->wl_dmabuf =
 		    wl_registry_bind(registry, name,
-				     &zwp_linux_dmabuf_v1_interface, 2);
+				     &zwp_linux_dmabuf_v1_interface, 3);
 		wl_dmabuf = d->wl_dmabuf;
 	}
 }


### PR DESCRIPTION
The version number of the wrong interface had been changed.

Signed-off-by: Satyeshwar Singh <satyeshwar.singh@intel.com>