### PR TITLE
vmdisplay-wayland: some critical fixes and adjustments

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -773,6 +773,7 @@ libvmdisplay_la_SOURCES = clients/vmdisplay/vmdisplay-parser.c \
 		clients/vmdisplay/vmdisplay.c		\
 		clients/vmdisplay/wayland-drm-protocol.c
 
+bin_PROGRAMS += vmdisplay-wayland
 vmdisplay_wayland_SOURCES =	clients/vmdisplay/vmdisplay-wayland.c
 nodist_vmdisplay_wayland_SOURCES =				\
 	protocol/ias-shell-server-protocol.h    \
@@ -785,6 +786,7 @@ vmdisplay_wayland_LDADD = $(COMPOSITOR_LIBS) $(GLIB_LIBS) $(EGL_LIBS) $(SIMPLE_C
 	$(SIMPLE_EGL_CLIENT_LIBS)               \
 	libias-@LIBWESTON_MAJOR@.la
 
+bin_PROGRAMS += vmdisplay-server
 vmdisplay_server_SOURCES = clients/vmdisplay/vmdisplay-server.cpp	\
 		clients/vmdisplay/vmdisplay-server-network.cpp		\
 		clients/vmdisplay/vmdisplay-server-hyperdmabuf.cpp
@@ -792,6 +794,7 @@ vmdisplay_server_CFLAGS = $(AM_CFLAGS) $(GCC_CFLAGS)
 vmdisplay_server_LDADD =  $(GLIB_LIBS) \
 	libshared.la libvmdisplay.la -lm -lpthread
 
+bin_PROGRAMS += vmdisplay-input
 vmdisplay_input_SOURCES = clients/vmdisplay/vmdisplay-input.cpp
 nodist_vmdisplay_input_SOURCES = clients/vmdisplay/vmdisplay-server-network.cpp
 vmdisplay_input_CFLAGS = $(AM_CFLAGS) $(GCC_CFLAGS)

--- a/clients/vmdisplay/vmdisplay-wayland.c
+++ b/clients/vmdisplay/vmdisplay-wayland.c
@@ -1180,9 +1180,7 @@ int main(int argc, char **argv)
 	domid = atoi(argv[1]);
 	open_drm();
 
-#if 0
 	init_buffers();
-#endif
 
 	if (g_Dbg) {
 		printf("Debug:%d h:%d w:%d\n", g_Dbg, window.window_size.height,


### PR DESCRIPTION
update entry for the aged hyper_dmabuf with the latest everytime
new egl image is created with hyper_dmabuf. Also, added buffer list
initailzation to prevent segfault before using buffer list structure.

Changes in Makefile.am is for including vmdisplay-* tools in the list
of executables to be installed.

General code clean-up is also included.

Signed-off-by: Dongwon Kim <dongwon.kim@intel.com>