### PR TITLE
vmdisplay-server-hyperdmabuf: multi frames support

### DIFF
--- a/clients/vmdisplay/vmdisplay-server-hyperdmabuf.h
+++ b/clients/vmdisplay/vmdisplay-server-hyperdmabuf.h
@@ -52,7 +52,8 @@ private:
 	struct vm_header *hdr;
 	struct vm_buffer_info *buf_info;
 	int offset[VM_MAX_OUTPUTS];
-	int last_counter;
+	int last_counter[VM_MAX_OUTPUTS];
+	int num_buffers[VM_MAX_OUTPUTS];
 };
 
 #endif // _VMDISPLAY_SERVER_HYPERDMABUF_H_


### PR DESCRIPTION
vm_header from different output/guest should be separtely handled.
For this, last_counters are redefined as array to support multiple
outputs(frames) and a new array, "num_buffers" are added to keep
track of number of hyper dmabuf buffers (surfaces) for each output
(frame) separately.

Signed-off-by: Wan Shuang <shuang.wan@intel.com>
Signed-off-by: Dongwon Kim <dongwon.kim@intel.com>