### PR TITLE
vmdisplay-server: general clean-ups

### DIFF
--- a/clients/vmdisplay/vm-shared.h
+++ b/clients/vmdisplay/vm-shared.h
@@ -37,16 +37,14 @@
 
 #define SURFACE_NAME_LENGTH     64
 #define BIT(a)                  (1<<a)
-/*
- * If a buffer has been updated by a VM client app, the status field will have
- * this UPDATED bit set. Otherwise, it would have this bit cleared
- */
+
+// If a buffer has been updated by a VM client app, the status field will have
+// this UPDATED bit set. Otherwise, it would have this bit cleared
 #define UPDATED                 BIT(0)
-/*
- * Some fields may not have been filled by the compositor and stay unused.
- * Those would be marked as UNUSED_FIELD. For example, currently the
- * tile_format is not populated by the compositor and will be set to this.
- */
+
+// Some fields may not have been filled by the compositor and stay unused.
+// Those would be marked as UNUSED_FIELD. For example, currently the
+// tile_format is not populated by the compositor and will be set to this.
 #define UNUSED_FIELD            (BIT(16) - 1)
 
 struct vm_header {
@@ -77,26 +75,22 @@ struct vm_buffer_info {
 	int32_t bbox[4];
 };
 
-/*
- * Metadata is being send as stream by compositor,
- * To be able to easily extract single frame from such stream,
- * special markers are used to mark beginning and end of single frame,
- * 0xF00D and 0xCAFE.
- */
+// Metadata is being send as stream by compositor,
+// To be able to easily extract single frame from such stream,
+// special markers are used to mark beginning and end of single frame,
+// 0xF00D and 0xCAFE.
 #define METADATA_STREAM_START 0xF00D
 #define METADATA_STREAM_END 0xCAFE
 
 #define VM_MAX_OUTPUTS 12
 
-/*
- * Depending on implementation of communication channel it may
- * be preallocating some memory space that will be used for communication.
- * In case when not enough memory will be allocated it may happen that metadata for
- * single frame won't fit in that memory. Due to performance reasons it's better
- * if whole metadata of single frame can be transmitted at once.
- * Below value is metadata size of frame containing ~80 surfaces, which can be used as hint
- * during initialization of communication channel
- */
+// Depending on implementation of communication channel it may
+// be preallocating some memory space that will be used for communication.
+// In case when not enough memory will be allocated it may happen that
+// metadata for single frame won't fit in that memory. Due to performance
+// reasons it's better if whole metadata of single frame can be transmitted
+// at once. Below value is metadata size of frame containing ~80 surfaces,
+// which can be used as hint during initialization of communication channel
 #define METADATA_BUFFER_SIZE 12000
 
 #endif

--- a/clients/vmdisplay/vmdisplay-parser.h
+++ b/clients/vmdisplay/vmdisplay-parser.h
@@ -29,8 +29,8 @@
  *   VMDisplay parse metadata
  *-----------------------------------------------------------------------------
  */
-#ifndef _VMRECEPTOR_H_
-#define _VMRECEPTOR_H_
+#ifndef _VMDISPLAY_PARSER_H_
+#define _VMDISPLAY_PARSER_H_
 
 #include <stdint.h>
 #include <GLES2/gl2.h>
@@ -59,4 +59,4 @@ extern int32_t disp_h;
 int parse_event_metadata(int fd, int *counter);
 int parse_socket_metadata(vmdisplay_socket * socket, int *counter);
 
-#endif
+#endif // _VMDISPLAY_PARSER_H_

--- a/clients/vmdisplay/vmdisplay-server-hyperdmabuf.cpp
+++ b/clients/vmdisplay/vmdisplay-server-hyperdmabuf.cpp
@@ -39,6 +39,10 @@
 #include <stdio.h>
 #include "vmdisplay-server-hyperdmabuf.h"
 
+#define METADATA_SZ (sizeof(struct vm_header) +\
+		     sizeof(struct vm_buffer_info) +\
+		     sizeof(struct hyper_dmabuf_event_hdr))
+
 int HyperDMABUFCommunicator::init(int domid,
 				  HyperCommunicatorDirection dir,
 				  const char *args)
@@ -59,14 +63,9 @@ int HyperDMABUFCommunicator::init(int domid,
 
 	direction = dir;
 
-	metadata = new char[sizeof(struct vm_header) +
-			    sizeof(struct vm_buffer_info) +
-			    sizeof(struct hyper_dmabuf_event_hdr)];
+	metadata = new char[METADATA_SZ];
 
-	hdr = NULL;
-	buf_info = NULL;
-
-	/* intializing frame paratmers */
+	// intializing frame paratmers
 	for (int i = 0; i < VM_MAX_OUTPUTS; i++) {
 		last_counter[i] = -1;
 		num_buffers[i] = 0;
@@ -87,38 +86,28 @@ void HyperDMABUFCommunicator::cleanup()
 	metadata = NULL;
 }
 
-int HyperDMABUFCommunicator::recv_data(void *buffer, int max_len)
+static int event_poll(int fd, void *buffer, int max_len)
 {
 	struct pollfd fds = { };
 	int ret = -1;
 
-	fds.fd = hyper_dmabuf_fd;
+	fds.fd = fd;
 	fds.events = POLLIN;
 
-	if (direction == HyperCommunicatorInterface::Receiver) {
-		do {
-			ret = poll(&fds, 1, -1);
-			if (ret > 0) {
-				if (fds.revents & (POLLERR | POLLNVAL)) {
-					errno = EINVAL;
-					return -1;
-				}
-				break;
+	do {
+		ret = poll(&fds, 1, -1);
+		if (ret > 0) {
+			if (fds.revents & (POLLERR | POLLNVAL)) {
+				errno = EINVAL;
+				return -1;
 			}
-		} while (ret == -1 && (errno == EINTR || errno == EAGAIN));
+			break;
+		}
+	} while (ret == -1 && (errno == EINTR || errno == EAGAIN));
 
-		ret = read(hyper_dmabuf_fd, buffer, max_len);
-	}
+	ret = read(fd, buffer, max_len);
 
 	return ret;
-}
-
-int HyperDMABUFCommunicator::send_data(const void *buffer, int len)
-{
-	UNUSED(buffer);
-	UNUSED(len);
-
-	return -1;
 }
 
 int HyperDMABUFCommunicator::recv_metadata(void **buffer)
@@ -127,13 +116,22 @@ int HyperDMABUFCommunicator::recv_metadata(void **buffer)
 
 	struct hyper_dmabuf_event_hdr *event_hdr;
 
+	struct vm_header *hdr = (struct vm_header *)
+			&metadata[sizeof(struct hyper_dmabuf_event_hdr)];
+
+	struct vm_buffer_info *buf_info = (struct vm_buffer_info *)
+			&metadata[sizeof(struct hyper_dmabuf_event_hdr) +
+			sizeof(struct vm_header)];
+
+	// only works if direction set for 'Receiver'
+	if (direction != HyperCommunicatorInterface::Receiver)
+		return -1;
+
 	while (1) {
-		/*
-		 * In case when we received alreay buffer for next frame,
-		 * append its metadata to new frame metadata.
-		 */
+		 // In case when we already received buffer for next frame,
+		 // append its metadata to new frame metadata.
 		if (hdr && hdr->counter != last_counter[hdr->output]) {
-			/* Copy metatadat to mmaped file of given output */
+			// Copy metatadat to mmaped file of given output
 			memcpy((char *)buffer[hdr->output] +
 			       offset[hdr->output], buf_info,
 			       sizeof(struct vm_buffer_info));
@@ -141,41 +139,28 @@ int HyperDMABUFCommunicator::recv_metadata(void **buffer)
 			num_buffers[hdr->output]++;
 			last_counter[hdr->output] = hdr->counter;
 		} else if (hdr) {
-			/* invalidating previous hdr */
+			// invalidating previous hdr
 			last_counter[hdr->output] = -1;
 		}
 
 		do {
-			len = recv_data(metadata,
-					sizeof(struct vm_header) +
-					sizeof(struct vm_buffer_info) +
-					sizeof(struct hyper_dmabuf_event_hdr));
-
+			len = event_poll(hyper_dmabuf_fd, metadata,
+					 METADATA_SZ);
 		} while(len < 0);
 
 		event_hdr = (struct hyper_dmabuf_event_hdr *)&metadata[0];
 
-		hdr =
-		    (struct vm_header *)
-		    &metadata[sizeof(struct hyper_dmabuf_event_hdr)];
-
-		buf_info =
-		    (struct vm_buffer_info *)
-		    &metadata[sizeof(struct hyper_dmabuf_event_hdr) +
-			      sizeof(struct vm_header)];
-
-		/* Copy HID from event_hdr */
+		// Copy HID from event_hdr
 		buf_info->hyper_dmabuf_id = event_hdr->hid;
 
 		if (hdr->output < VM_MAX_OUTPUTS) {
-			/*
-			 * Check if we received buffer from the same frame,
-			 * if so, append its metadata to frame metadata.
-			 */
+			// Check if we received buffer (surface) from the
+			// same frame, if so, append new buffer info to the
+			// of previuos metadata.
 			if (last_counter[hdr->output] == -1 ||
 			    hdr->counter == last_counter[hdr->output]) {
-				/* Copy metadata to mmaped file of
-				 * given output */
+				// Copy metadata to mmaped file of
+				// given output
 				memcpy((char *)buffer[hdr->output] +
 				       offset[hdr->output], buf_info,
 				       sizeof(struct vm_buffer_info));
@@ -185,11 +170,9 @@ int HyperDMABUFCommunicator::recv_metadata(void **buffer)
 				last_counter[hdr->output] = hdr->counter;
 			}
 
-			/*
-			 * In case that we received buffer for new frame, or
-			 * we received all buffers for current frame, send out
-			 * new frame metadata to clients.
-			 */
+			// In case that we received buffer for new frame, or
+			// we received all buffers for current frame, send out
+			// new frame metadata to clients.
 			if (hdr->counter != last_counter[hdr->output] ||
 			    num_buffers[hdr->output] >= hdr->n_buffers) {
 				memcpy(buffer[hdr->output], hdr,

--- a/clients/vmdisplay/vmdisplay-server-hyperdmabuf.h
+++ b/clients/vmdisplay/vmdisplay-server-hyperdmabuf.h
@@ -41,8 +41,6 @@ public:
 	int init(int domid, HyperCommunicatorDirection direction,
 		 const char *name);
 	void cleanup();
-	int recv_data(void *data, int len);
-	int send_data(const void *data, int len);
 	int recv_metadata(void **buffers);
 
 private:

--- a/clients/vmdisplay/vmdisplay-server-network.cpp
+++ b/clients/vmdisplay/vmdisplay-server-network.cpp
@@ -59,7 +59,7 @@ int NetworkCommunicator::init(int domid, HyperCommunicatorDirection dir,
 	struct hostent *server;
 	int portno;
 	struct sockaddr_in server_addr;
-	/* Local copy of args, as strtok is modyfing it */
+	// Local copy of args, as strtok is modyfing it
 	char args_tmp[255];
 	char *addr;
 	char *port;
@@ -195,7 +195,7 @@ int NetworkCommunicator::recv_data(void *buffer, int max_len)
 	if (direction == HyperCommunicatorInterface::Receiver) {
 		ret = recv(sock_fd, buffer, max_len, 0);
 		if (ret == 0) {
-			/* 0 return means socket closed, singal this as error */
+			// 0 return means socket closed, singal this as error
 			ret = -1;
 		}
 	}
@@ -222,7 +222,7 @@ int NetworkCommunicator::recv_metadata(void **surfaces_metadata)
 		start_offset = -1;
 		end_offset = -1;
 
-		/* Look for frame metadata start/end markers */
+		// Look for frame metadata start/end markers
 		for (int i = 0; i < metadata_offset; i++) {
 			int marker = *(int *)(&metadata[i]);
 
@@ -238,7 +238,8 @@ int NetworkCommunicator::recv_metadata(void **surfaces_metadata)
 			}
 		}
 
-		/* If whole frame metadata was received, parse for which output it is and return */
+		// If whole frame metadata was received, parse for which output
+		// it is and return
 		if (start_offset != -1 && end_offset != -1
 		    && end_offset > start_offset) {
 			header = (struct vm_header *)(&metadata[start_offset]);
@@ -270,7 +271,7 @@ int NetworkCommunicator::send_data(const void *buffer, int len)
 			client_sock_fd = -1;
 			pthread_create(&listener_thread, NULL,
 				       listener_thread_func, this);
-			/* 0 return means socket closed, singal this as error */
+			// 0 return means socket closed, singal this as error
 			ret = -1;
 		}
 	}

--- a/clients/vmdisplay/vmdisplay-server.cpp
+++ b/clients/vmdisplay/vmdisplay-server.cpp
@@ -53,22 +53,18 @@
 #include "vmdisplay-server-hyperdmabuf.h"
 #include "vmdisplay-server-network.h"
 
-/*
- * Number of pending connections that can be queued,
- * until new vmdisplay-wayland instances will be getting
- * error during connection
- */
+// Number of pending connections that can be queued,
+// until new vmdisplay-wayland instances will be getting
+// error during connection
 #define SOCKET_BACKLOG 25
 
 struct output_data {
-	/*
-	 * File descriptor to anonymous
-	 * file that will contain metadata
-	 * of surfaces placed on given output
-	 */
+	// File descriptor to anonymous
+	// file that will contain metadata
+	// of surfaces placed on given output
 	int shm_fd;
 
-	/* Address of mmaped metadata file */
+	// Address of mmaped metadata file
 	void *shm_addr;
 };
 
@@ -171,7 +167,8 @@ int VMDisplayServer::init_outputs()
 {
 	char path[255];
 
-	/* Create for each possible output its metadata file (and unlink it, so it becomes anonymouse one */
+	// Create for each possible output its metadata file and unlink it,
+	// so it becomes anonymouse one
 	for (int i = 0; i < VM_MAX_OUTPUTS; ++i) {
 		snprintf(path, 255, "/run/vmdisplay_%d_metadata", i);
 		outputs[i].shm_fd =
@@ -346,15 +343,16 @@ int VMDisplayServer::run()
 				perror("Accept error\n");
 				continue;
 			} else {
-				/* New client has connected */
+				// New client has connected
 				pthread_mutex_lock(&mutex);
-				/* Make its socket nonblocking */
+				// Make its socket nonblocking
 				fcntl(client_sockfd, F_SETFL,
 				      fcntl(client_sockfd, F_GETFL,
 					    0) | O_NONBLOCK);
 				client_sockets.push_back(client_sockfd);
 
-				/*Send init message and fds of all outputs metadata files */
+				// Send init message and fds of all outputs
+				// metadata files
 				send_message(client_sockfd, VMDISPLAY_INIT_MSG,
 					     VM_MAX_OUTPUTS);
 				for (int i = 0; i < VM_MAX_OUTPUTS; i++)
@@ -386,7 +384,8 @@ int VMDisplayServer::process_metadata()
 		output_num =
 		    hyper_comm_metadata->recv_metadata(surfaces_metadata);
 
-		/* TODO decide if we should be waiting for weston to start again or just retun error and restart whole vmdisplay server */
+		// TODO decide if we should be waiting for weston to start
+		// again or just retun error and restart whole vmdisplay server
 		if (output_num < 0) {
 			printf("Lost connection to Dom%d compositor\n", domid);
 			running = false;
@@ -396,7 +395,8 @@ int VMDisplayServer::process_metadata()
 		pthread_mutex_lock(&mutex);
 
 		std::vector < int >::iterator it;
-		for (it = client_sockets.begin(); it != client_sockets.end();) {
+		for (it = client_sockets.begin();
+		     it != client_sockets.end();) {
 			rc = send_message((*it), VMDISPLAY_METADATA_UPDATE_MSG,
 					  output_num);
 			if (rc < 0) {
@@ -423,7 +423,7 @@ int VMDisplayServer::process_input()
 	struct vmdisplay_key_event key_event;
 	struct vmdisplay_pointer_event pointer_event;
 	int rc, i;
-	/* TODO assuming now that max 255 client apps will be running */
+	// TODO assuming now that max 255 client apps will be running
 	struct pollfd fds[255];
 
 	while (running) {

--- a/clients/vmdisplay/vmdisplay-server.h
+++ b/clients/vmdisplay/vmdisplay-server.h
@@ -48,8 +48,20 @@ public:
 	virtual int init(int dom_id, HyperCommunicatorDirection direction,
 			 const char *args) = 0;
 	virtual void cleanup() = 0;
-	virtual int recv_data(void *data, int len) = 0;
-	virtual int send_data(const void *data, int len) = 0;
+	virtual int recv_data(void *data, int len)
+	{
+		UNUSED(data);
+		UNUSED(len);
+		return 0;
+	}
+
+	virtual int send_data(const void *data, int len)
+	{
+		UNUSED(data);
+		UNUSED(len);
+		return 0;
+	}
+
 	virtual int recv_metadata(void **surfaces_metadata) = 0;
 };
 

--- a/clients/vmdisplay/vmdisplay-shared.h
+++ b/clients/vmdisplay/vmdisplay-shared.h
@@ -30,8 +30,8 @@
  *-----------------------------------------------------------------------------
  */
 
-#ifndef __VMDISPLAY_SHARED_H__
-#define __VMDISPLAY_SHARED_H__
+#ifndef _VMDISPLAY_SHARED_H_
+#define _VMDISPLAY_SHARED_H_
 
 #include <stdint.h>
 
@@ -120,4 +120,4 @@ struct vmdisplay_pointer_event {
 	};
 };
 
-#endif
+#endif // _VMDISPLAY_SHARED_H_

--- a/clients/vmdisplay/vmdisplay.h
+++ b/clients/vmdisplay/vmdisplay.h
@@ -92,6 +92,7 @@ extern int enable_fps_info;
 extern uint32_t show_window;
 
 int open_drm(void);
+void init_buffers(void);
 int init_hyper_dmabuf(int dom);
 void clear_hyper_dmabuf_list(void);
 void create_new_hyper_dmabuf_buffer(void);


### PR DESCRIPTION
- removed uncessary member functions and variables
- cleaned up routine to use less # of variables
- use "C++ style" comment style in C++ source and headers

Signed-off-by: root <root@dongwonk-Z87X-UD5H.fm.intel.com>