### PR TITLE
vmdisplay-server: general clean-ups

### DIFF
--- a/clients/vmdisplay/vmdisplay-parser.h
+++ b/clients/vmdisplay/vmdisplay-parser.h
@@ -29,8 +29,8 @@
  *   VMDisplay parse metadata
  *-----------------------------------------------------------------------------
  */
-#ifndef _VMRECEPTOR_H_
-#define _VMRECEPTOR_H_
+#ifndef _VMDISPLAY_PARSER_H_
+#define _VMDISPLAY_PARSER_H_
 
 #include <stdint.h>
 #include <GLES2/gl2.h>
@@ -59,4 +59,4 @@ extern int32_t disp_h;
 int parse_event_metadata(int fd, int *counter);
 int parse_socket_metadata(vmdisplay_socket * socket, int *counter);
 
-#endif
+#endif // _VMDISPLAY_PARSER_H_

--- a/clients/vmdisplay/vmdisplay-server-hyperdmabuf.h
+++ b/clients/vmdisplay/vmdisplay-server-hyperdmabuf.h
@@ -41,8 +41,6 @@ public:
 	int init(int domid, HyperCommunicatorDirection direction,
 		 const char *name);
 	void cleanup();
-	int recv_data(void *data, int len);
-	int send_data(const void *data, int len);
 	int recv_metadata(void **buffers);
 
 private:

--- a/clients/vmdisplay/vmdisplay-server-network.cpp
+++ b/clients/vmdisplay/vmdisplay-server-network.cpp
@@ -238,7 +238,10 @@ int NetworkCommunicator::recv_metadata(void **surfaces_metadata)
 			}
 		}
 
-		/* If whole frame metadata was received, parse for which output it is and return */
+		/*
+		 * If whole frame metadata was received, parse for which output
+		 * it is and return
+		 */
 		if (start_offset != -1 && end_offset != -1
 		    && end_offset > start_offset) {
 			header = (struct vm_header *)(&metadata[start_offset]);

--- a/clients/vmdisplay/vmdisplay-server.cpp
+++ b/clients/vmdisplay/vmdisplay-server.cpp
@@ -171,7 +171,10 @@ int VMDisplayServer::init_outputs()
 {
 	char path[255];
 
-	/* Create for each possible output its metadata file (and unlink it, so it becomes anonymouse one */
+	/*
+	 * Create for each possible output its metadata file and unlink it,
+	 * so it becomes anonymouse one
+	 */
 	for (int i = 0; i < VM_MAX_OUTPUTS; ++i) {
 		snprintf(path, 255, "/run/vmdisplay_%d_metadata", i);
 		outputs[i].shm_fd =
@@ -354,7 +357,10 @@ int VMDisplayServer::run()
 					    0) | O_NONBLOCK);
 				client_sockets.push_back(client_sockfd);
 
-				/*Send init message and fds of all outputs metadata files */
+				/*
+				 * Send init message and fds of all outputs
+				 * metadata files
+				 */
 				send_message(client_sockfd, VMDISPLAY_INIT_MSG,
 					     VM_MAX_OUTPUTS);
 				for (int i = 0; i < VM_MAX_OUTPUTS; i++)
@@ -386,7 +392,10 @@ int VMDisplayServer::process_metadata()
 		output_num =
 		    hyper_comm_metadata->recv_metadata(surfaces_metadata);
 
-		/* TODO decide if we should be waiting for weston to start again or just retun error and restart whole vmdisplay server */
+		/*
+		 * TODO decide if we should be waiting for weston to start
+		 * again or just retun error and restart whole vmdisplay server
+		 */
 		if (output_num < 0) {
 			printf("Lost connection to Dom%d compositor\n", domid);
 			running = false;
@@ -396,7 +405,8 @@ int VMDisplayServer::process_metadata()
 		pthread_mutex_lock(&mutex);
 
 		std::vector < int >::iterator it;
-		for (it = client_sockets.begin(); it != client_sockets.end();) {
+		for (it = client_sockets.begin();
+		     it != client_sockets.end();) {
 			rc = send_message((*it), VMDISPLAY_METADATA_UPDATE_MSG,
 					  output_num);
 			if (rc < 0) {

--- a/clients/vmdisplay/vmdisplay-server.h
+++ b/clients/vmdisplay/vmdisplay-server.h
@@ -48,8 +48,20 @@ public:
 	virtual int init(int dom_id, HyperCommunicatorDirection direction,
 			 const char *args) = 0;
 	virtual void cleanup() = 0;
-	virtual int recv_data(void *data, int len) = 0;
-	virtual int send_data(const void *data, int len) = 0;
+	virtual int recv_data(void *data, int len)
+	{
+		UNUSED(data);
+		UNUSED(len);
+		return 0;
+	}
+
+	virtual int send_data(const void *data, int len)
+	{
+		UNUSED(data);
+		UNUSED(len);
+		return 0;
+	}
+
 	virtual int recv_metadata(void **surfaces_metadata) = 0;
 };
 

--- a/clients/vmdisplay/vmdisplay-shared.h
+++ b/clients/vmdisplay/vmdisplay-shared.h
@@ -30,8 +30,8 @@
  *-----------------------------------------------------------------------------
  */
 
-#ifndef __VMDISPLAY_SHARED_H__
-#define __VMDISPLAY_SHARED_H__
+#ifndef _VMDISPLAY_SHARED_H_
+#define _VMDISPLAY_SHARED_H_
 
 #include <stdint.h>
 
@@ -120,4 +120,4 @@ struct vmdisplay_pointer_event {
 	};
 };
 
-#endif
+#endif // _VMDISPLAY_SHARED_H_

--- a/clients/vmdisplay/vmdisplay.h
+++ b/clients/vmdisplay/vmdisplay.h
@@ -92,6 +92,7 @@ extern int enable_fps_info;
 extern uint32_t show_window;
 
 int open_drm(void);
+void init_buffers(void);
 int init_hyper_dmabuf(int dom);
 void clear_hyper_dmabuf_list(void);
 void create_new_hyper_dmabuf_buffer(void);


### PR DESCRIPTION
- removed uncessary member functions and variables
- cleaned up routine to use less # of variables

v2: added declaration of prototype of 'init_buffers'
v3: no "C++ style" comment change to comply with current policy

Signed-off-by: Dongwon Kim <dongwon.kim@intel.com>