### PR TITLE
vmdisplay: set correct tiled attribute for eglImage

### DIFF
--- a/clients/vmdisplay/vmdisplay.c
+++ b/clients/vmdisplay/vmdisplay.c
@@ -286,6 +286,7 @@ int check_for_new_buffer(void)
 static void create_new_buffer_common(int dmabuf_fd)
 {
 	GLuint textureId[2];
+	GLint attribs[23], *attrib;
 	struct zwp_linux_buffer_params_v1 *params;
 	int i;
 
@@ -329,43 +330,33 @@ static void create_new_buffer_common(int dmabuf_fd)
 			current_textureId[0] = textureId[0];
 			current_textureId[1] = textureId[1];
 
-			EGLint imageAttributes_tex0[] = {
-				EGL_WIDTH, surf_width,
-				EGL_HEIGHT, surf_height,
-				EGL_LINUX_DRM_FOURCC_EXT, DRM_FORMAT_R8,
-				EGL_DMA_BUF_PLANE0_FD_EXT, dmabuf_fd,
-				EGL_DMA_BUF_PLANE0_OFFSET_EXT, surf_offset[0],
-				EGL_DMA_BUF_PLANE0_PITCH_EXT, surf_stride[0],
-				EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT,
-				fourcc_mod_code(INTEL,
-						surf_tile_format) & 0xFFFFFFFF,
-				EGL_DMA_BUF_PLANE0_MODIFIER_HI_EXT,
-				fourcc_mod_code(INTEL,
-						surf_tile_format) >> 32,
-				EGL_NONE
-			};
-			EGLint imageAttributes_tex1[] = {
-				EGL_WIDTH, surf_width / 2,
-				EGL_HEIGHT, surf_height / 2,
-				EGL_LINUX_DRM_FOURCC_EXT, DRM_FORMAT_GR88,
-				EGL_DMA_BUF_PLANE0_FD_EXT, dmabuf_fd,
-				EGL_DMA_BUF_PLANE0_OFFSET_EXT, surf_offset[1],
-				EGL_DMA_BUF_PLANE0_PITCH_EXT, surf_stride[1],
-				EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT,
-				fourcc_mod_code(INTEL,
-						surf_tile_format) & 0xFFFFFFFF,
-				EGL_DMA_BUF_PLANE0_MODIFIER_HI_EXT,
-				fourcc_mod_code(INTEL,
-						surf_tile_format) >> 32,
-				EGL_NONE
-			};
+			attrib = attribs;
+			*attrib++ = EGL_WIDTH;
+			*attrib++ = surf_width;
+			*attrib++ = EGL_HEIGHT;
+			*attrib++ = surf_height;
+			*attrib++ = EGL_LINUX_DRM_FOURCC_EXT;
+			*attrib++ = DRM_FORMAT_R8;
+			*attrib++ = EGL_DMA_BUF_PLANE0_FD_EXT;
+			*attrib++ = dmabuf_fd;
+			*attrib++ = EGL_DMA_BUF_PLANE0_OFFSET_EXT;
+			*attrib++ = surf_offset[0];
+			*attrib++ = EGL_DMA_BUF_PLANE0_PITCH_EXT;
+			*attrib++ = surf_stride[0];
+			if (surf_tile_format == I915_TILING_X || surf_tile_format == I915_TILING_Y) {
+				*attrib++ = EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT;
+				*attrib++ = fourcc_mod_code(INTEL, surf_tile_format) & 0xFFFFFFFF;
+				*attrib++ = EGL_DMA_BUF_PLANE0_MODIFIER_HI_EXT;
+				*attrib++ = fourcc_mod_code(INTEL, surf_tile_format) >> 32;
+			}
+			*attrib++ = EGL_NONE;
 
 			glBindTexture(GL_TEXTURE_2D, textureId[0]);
 			khr_image =
 			    create_image((EGLDisplay) g_eman_common.dpy,
 					 EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT,
 					 (EGLClientBuffer) NULL,
-					 imageAttributes_tex0);
+					 attribs);
 
 			if (khr_image) {
 				image_target_texture_2d(GL_TEXTURE_2D,
@@ -373,60 +364,75 @@ static void create_new_buffer_common(int dmabuf_fd)
 				destroy_image(g_eman_common.dpy, khr_image);
 
 				glBindTexture(GL_TEXTURE_2D, textureId[1]);
+				attrib = attribs;
+				*attrib++ = EGL_WIDTH;
+				*attrib++ = (surf_width+1)/2;
+				*attrib++ = EGL_HEIGHT;
+				*attrib++ = (surf_height+1)/2;
+				*attrib++ = EGL_LINUX_DRM_FOURCC_EXT;
+				*attrib++ = DRM_FORMAT_GR88;
+				*attrib++ = EGL_DMA_BUF_PLANE0_FD_EXT;
+				*attrib++ = dmabuf_fd;
+				*attrib++ = EGL_DMA_BUF_PLANE0_OFFSET_EXT;
+				*attrib++ = surf_offset[1];
+				*attrib++ = EGL_DMA_BUF_PLANE0_PITCH_EXT;
+				*attrib++ = surf_stride[1];
+				if (surf_tile_format == I915_TILING_X || surf_tile_format == I915_TILING_Y) {
+					*attrib++ = EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT;
+					*attrib++ = fourcc_mod_code(INTEL, surf_tile_format) & 0xFFFFFFFF;
+					*attrib++ = EGL_DMA_BUF_PLANE0_MODIFIER_HI_EXT;
+					*attrib++ = fourcc_mod_code(INTEL, surf_tile_format) >> 32;
+				}
+				*attrib++ = EGL_NONE;
 				khr_image =
 				    create_image((EGLDisplay) g_eman_common.dpy,
 						 EGL_NO_CONTEXT,
 						 EGL_LINUX_DMA_BUF_EXT,
 						 (EGLClientBuffer) NULL,
-						 imageAttributes_tex1);
+						 attribs);
 				image_target_texture_2d(GL_TEXTURE_2D,
 							khr_image);
 				destroy_image(g_eman_common.dpy, khr_image);
 				current_texture_sampler_format =
 				    DRM_FORMAT_NV12;
 			} else {
-				EGLint imageAttributes[] = {
-					EGL_WIDTH, surf_width,
-					EGL_HEIGHT, surf_height,
-					EGL_LINUX_DRM_FOURCC_EXT,
-					DRM_FORMAT_NV12,
-					EGL_YUV_COLOR_SPACE_HINT_EXT,
-					EGL_ITU_REC601_EXT,
-					EGL_SAMPLE_RANGE_HINT_EXT,
-					EGL_YUV_NARROW_RANGE_EXT,
-					EGL_DMA_BUF_PLANE0_FD_EXT, dmabuf_fd,
-					EGL_DMA_BUF_PLANE0_OFFSET_EXT,
-					surf_offset[0],
-					EGL_DMA_BUF_PLANE0_PITCH_EXT,
-					surf_stride[0],
-					EGL_DMA_BUF_PLANE1_FD_EXT, dmabuf_fd,
-					EGL_DMA_BUF_PLANE1_OFFSET_EXT,
-					surf_offset[1],
-					EGL_DMA_BUF_PLANE1_PITCH_EXT,
-					surf_stride[1],
-					EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT,
-					fourcc_mod_code(INTEL,
-							surf_tile_format) &
-					    0xFFFFFFFF,
-					EGL_DMA_BUF_PLANE0_MODIFIER_HI_EXT,
-					fourcc_mod_code(INTEL,
-							surf_tile_format) >> 32,
-					EGL_DMA_BUF_PLANE1_MODIFIER_LO_EXT,
-					fourcc_mod_code(INTEL,
-							surf_tile_format) &
-					    0xFFFFFFFF,
-					EGL_DMA_BUF_PLANE1_MODIFIER_HI_EXT,
-					fourcc_mod_code(INTEL,
-							surf_tile_format) >> 32,
-					EGL_NONE
-				};
+				attrib = attribs;
+				*attrib++ = EGL_WIDTH;
+				*attrib++ = surf_width;
+				*attrib++ = EGL_HEIGHT;
+				*attrib++ = surf_height;
+				*attrib++ = EGL_LINUX_DRM_FOURCC_EXT;
+				*attrib++ = DRM_FORMAT_NV12;
+				*attrib++ = EGL_DMA_BUF_PLANE0_FD_EXT;
+				*attrib++ = dmabuf_fd;
+				*attrib++ = EGL_DMA_BUF_PLANE0_OFFSET_EXT;
+				*attrib++ = surf_offset[0];
+				*attrib++ = EGL_DMA_BUF_PLANE0_PITCH_EXT;
+				*attrib++ = surf_stride[0];
+				*attrib++ = EGL_DMA_BUF_PLANE1_FD_EXT;
+				*attrib++ = dmabuf_fd;
+				*attrib++ = EGL_DMA_BUF_PLANE1_OFFSET_EXT;
+				*attrib++ = surf_offset[1];
+				*attrib++ = EGL_DMA_BUF_PLANE1_PITCH_EXT;
+				*attrib++ = surf_stride[1];
+				if (surf_tile_format == I915_TILING_X || surf_tile_format == I915_TILING_Y) {
+					*attrib++ = EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT;
+					*attrib++ = fourcc_mod_code(INTEL, surf_tile_format) & 0xFFFFFFFF;
+					*attrib++ = EGL_DMA_BUF_PLANE0_MODIFIER_HI_EXT;
+					*attrib++ = fourcc_mod_code(INTEL, surf_tile_format) >> 32;
+				}
+				*attrib++ = EGL_YUV_COLOR_SPACE_HINT_EXT;
+				*attrib++ = EGL_ITU_REC601_EXT ;
+				*attrib++ = EGL_SAMPLE_RANGE_HINT_EXT;
+				*attrib++ = EGL_YUV_NARROW_RANGE_EXT;
+				*attrib++ = EGL_NONE;
 
 				khr_image =
 				    create_image((EGLDisplay) g_eman_common.dpy,
 						 EGL_NO_CONTEXT,
 						 EGL_LINUX_DMA_BUF_EXT,
 						 (EGLClientBuffer) NULL,
-						 imageAttributes);
+						 attribs);
 
 				if (khr_image) {
 					image_target_texture_2d(GL_TEXTURE_2D,
@@ -437,7 +443,7 @@ static void create_new_buffer_common(int dmabuf_fd)
 					current_texture_sampler_format =
 					    DRM_FORMAT_ARGB8888;
 				} else {
-					printf("DRI driver doesn't support NV12\n");
+					printf("DRI not supporing NV12\n");
 					return;
 				}
 			}
@@ -452,53 +458,63 @@ static void create_new_buffer_common(int dmabuf_fd)
 			glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER,
 					GL_LINEAR);
 
-			EGLint imageAttributes[] = {
-				EGL_WIDTH, surf_width,
-				EGL_HEIGHT, surf_height,
-				EGL_LINUX_DRM_FOURCC_EXT, surf_format,
-				EGL_DMA_BUF_PLANE0_FD_EXT, dmabuf_fd,
-				EGL_DMA_BUF_PLANE0_OFFSET_EXT, 0,
-				EGL_DMA_BUF_PLANE0_PITCH_EXT, surf_stride[0],
-				EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT,
-				fourcc_mod_code(INTEL,
-						surf_tile_format) & 0xFFFFFFFF,
-				EGL_DMA_BUF_PLANE0_MODIFIER_HI_EXT,
-				fourcc_mod_code(INTEL,
-						surf_tile_format) >> 32,
-				EGL_NONE
-			};
+			attrib = attribs;
+			*attrib++ = EGL_WIDTH;
+			*attrib++ = surf_width;
+			*attrib++ = EGL_HEIGHT;
+			*attrib++ = surf_height;
+			*attrib++ = EGL_LINUX_DRM_FOURCC_EXT;
+			*attrib++ = surf_format;
+			*attrib++ = EGL_DMA_BUF_PLANE0_FD_EXT;
+			*attrib++ = dmabuf_fd;
+			*attrib++ = EGL_DMA_BUF_PLANE0_OFFSET_EXT;
+			*attrib++ = 0;
+			*attrib++ = EGL_DMA_BUF_PLANE0_PITCH_EXT;
+			*attrib++ = surf_stride[0];
+			if (surf_tile_format == I915_TILING_X || surf_tile_format == I915_TILING_Y) {
+				*attrib++ = EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT;
+				*attrib++ = fourcc_mod_code(INTEL, surf_tile_format) & 0xFFFFFFFF;
+				*attrib++ = EGL_DMA_BUF_PLANE0_MODIFIER_HI_EXT;
+				*attrib++ = fourcc_mod_code(INTEL, surf_tile_format) >> 32;
+			}
+			*attrib++ = EGL_NONE;
 
-			/* In case that DRI does not support natively YUYV import it as ARGB888 */
-			EGLint imageAttributesYUYVFallback[] = {
-				EGL_WIDTH, surf_width / 2,
-				EGL_HEIGHT, surf_height,
-				EGL_LINUX_DRM_FOURCC_EXT, DRM_FORMAT_ARGB8888,
-				EGL_DMA_BUF_PLANE0_FD_EXT, dmabuf_fd,
-				EGL_DMA_BUF_PLANE0_OFFSET_EXT, 0,
-				EGL_DMA_BUF_PLANE0_PITCH_EXT, surf_stride[0],
-				EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT,
-				fourcc_mod_code(INTEL,
-						surf_tile_format) & 0xFFFFFFFF,
-				EGL_DMA_BUF_PLANE0_MODIFIER_HI_EXT,
-				fourcc_mod_code(INTEL,
-						surf_tile_format) >> 32,
-				EGL_NONE
-			};
 
 			khr_image =
 			    create_image((EGLDisplay) g_eman_common.dpy,
 					 EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT,
 					 (EGLClientBuffer) NULL,
-					 imageAttributes);
+					 attribs);
 			/* UFO imports YUYV and on fly is doing color conversion, so in shader such texture behaves like regular RGB texture */
 			current_texture_sampler_format = DRM_FORMAT_ARGB8888;
 			if (!khr_image) {
+				/* In case that DRI does not support natively YUYV import it as ARGB888 */
+				attrib = attribs;
+				*attrib++ = EGL_WIDTH;
+				*attrib++ = surf_width/2;
+				*attrib++ = EGL_HEIGHT;
+				*attrib++ = surf_height;
+				*attrib++ = EGL_LINUX_DRM_FOURCC_EXT;
+				*attrib++ = DRM_FORMAT_ARGB8888;
+				*attrib++ = EGL_DMA_BUF_PLANE0_FD_EXT;
+				*attrib++ = dmabuf_fd;
+				*attrib++ = EGL_DMA_BUF_PLANE0_OFFSET_EXT;
+				*attrib++ = 0;
+				*attrib++ = EGL_DMA_BUF_PLANE0_PITCH_EXT;
+				*attrib++ = surf_stride[0];
+				if (surf_tile_format == I915_TILING_X || surf_tile_format == I915_TILING_Y) {
+					*attrib++ = EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT;
+					*attrib++ = fourcc_mod_code(INTEL, surf_tile_format) & 0xFFFFFFFF;
+					*attrib++ = EGL_DMA_BUF_PLANE0_MODIFIER_HI_EXT;
+					*attrib++ = fourcc_mod_code(INTEL, surf_tile_format) >> 32;
+				}
+				*attrib++ = EGL_NONE;
 				khr_image =
 				    create_image((EGLDisplay) g_eman_common.dpy,
 						 EGL_NO_CONTEXT,
 						 EGL_LINUX_DMA_BUF_EXT,
 						 (EGLClientBuffer) NULL,
-						 imageAttributesYUYVFallback);
+						 attribs);
 				current_texture_sampler_format =
 				    DRM_FORMAT_YUYV;
 			}


### PR DESCRIPTION
This is to fix issue that failed to generate texture for linear format
surface. Otherwise the texture is something red for RGB format dma-buf,
and failed to generate eglImage from NV12 format dma-buf

V2: check tiled attribute dynamically

Tracked-On: https://github.com/intel/ias/issues/62
Signed-off-by: Liu Xinyun <xinyun.liu@intel.com>