### PR TITLE
ias-shell: Cleanup capture proxy on application termination

### DIFF
--- a/clients/RemoteDisplay/main.h
+++ b/clients/RemoteDisplay/main.h
@@ -62,6 +62,7 @@ struct app_state {
 	enum encoder_state encoder_state;
 	char *transport_plugin;
 	char *plugin_fullname;
+	int surface_destroyed;
 	struct rd_encoder *rd_encoder;
 	struct input_receiver_private_data *ir_priv;
 

--- a/libweston/ias-hmi.c
+++ b/libweston/ias-hmi.c
@@ -352,6 +352,9 @@ ias_hmi_start_capture(struct wl_client *client,
 		IAS_ERROR("Failed to start capture.");
 		ias_hmi_send_capture_error(shell_resource, (int32_t)pid, ret);
 	}
+
+	/* Set the flag, this is used for the client side destruction */
+	shsurf->captured = 1;
 #else
 	wl_resource_post_error(shell_resource,
 			WL_SHELL_ERROR_ROLE, "Frame capture not compiled in, to use frame capture configure with --enable-frame-capture");
@@ -407,6 +410,7 @@ ias_hmi_stop_capture(struct wl_client *client,
 		IAS_ERROR("Failed to stop capture.");
 		ias_hmi_send_capture_error(shell_resource, (int32_t)pid, ret);
 	}
+	shsurf->captured = 0;
 #else
 	wl_resource_post_error(shell_resource,
 			WL_SHELL_ERROR_ROLE, "Frame capture not compiled in, to use frame capture configure with --enable-frame-capture");

--- a/libweston/ias-shell.h
+++ b/libweston/ias-shell.h
@@ -269,6 +269,14 @@ struct ias_surface {
 	 * 1.
 	 */
 	uint32_t soc;
+
+#ifdef BUILD_REMOTE_DISPLAY
+	/*
+	 * Flag to indicate if the surface is being captured.
+	 * This is used for client side destruction.
+	 */
+	int captured;
+#endif
 };
 
 // whether surface is directly flipped or composited


### PR DESCRIPTION
If there is a remote-display instance which captures the surface
of another application, then there is a possibility that the application
gets terminated before the remote-display. In such cases, the capture
proxy of the corresponding surface is not cleaned up resulting in memory
leak. Moreover, if another application comes up and requests a surface
the compositor can assign the same surfid. In this case, the remote-display
instance to capture the newly created surface exits with failure to capture.
This commit fixes the above by cleaning up the capture proxy as well
if an application who has a surface gets terminated.

v2: Fixed indentation

Signed-off-by: Gowtham Hosamane <gowtham.hosamane@intel.com>