### PR TITLE
Add header to fix warning related to free and destroy

### DIFF
--- a/clients/RemoteDisplay/transport_plugin_udp.c
+++ b/clients/RemoteDisplay/transport_plugin_udp.c
@@ -19,6 +19,8 @@
  * IN THE SOFTWARE.
  */
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <wayland-util.h>
 #include <libdrm/intel_bufmgr.h>
 #include <unistd.h>


### PR DESCRIPTION
Add stdlib and string header files to fix warning related to
free and destroy that were used in transport plugin udp.

Signed-off-by: Romli, Khairul Anuar <khairul.anuar.romli@intel.com>