### PR TITLE
dma_test: Removed -E flag from the example.

### DIFF
--- a/clients/dma_test/readme.txt
+++ b/clients/dma_test/readme.txt
@@ -74,15 +74,15 @@ Running Instructions:
 Examples:
 
 To run HDMI:
-dma_test -d /dev/video16 -n 0 -I 1920,1080 -O 1920,1080 -b 3 -f RGB3 -r GL_DMA -E
+dma_test -d /dev/video16 -n 0 -I 1920,1080 -O 1920,1080 -b 3 -f RGB3 -r GL_DMA 
 
 To run camera:
-dma_test -d /dev/video16 -i -n 4 -I 720,480 -O 1920,1080 -b 3 -f UYVY -r GL_DMA -E 
+dma_test -d /dev/video16 -i -n 4 -I 720,480 -O 1920,1080 -b 3 -f UYVY -r GL_DMA 
 
 
 Example of output:
 
-dma_test -d /dev/video16 -n 0 -I 1920,1080 -O 1920,1080 -b 3 -f RGB3 -r GL_DMA -E
+dma_test -d /dev/video16 -n 0 -I 1920,1080 -O 1920,1080 -b 3 -f RGB3 -r GL_DMA 
 G_FMT(start): width = 1920, height = 1080, 4cc = XR24
 G_FMT(final): width = 1920, height = 1080, 4cc = XR24
 DMA TEST TIME STATS


### PR DESCRIPTION
Removed the -E flag in the examples given in readme.txt.
If -E flag is being used, dma_test tool will be using dma buffer
exported from the IPU instead of GPU, which the performance is not
optimized in that case.

Signed-off-by: Lee, Shea Qi <shea.qi.lee@intel.com>