### PR TITLE
dma_test: Added build option and removed -E flag in example.

### DIFF
--- a/clients/dma_test/meson.build
+++ b/clients/dma_test/meson.build
@@ -1,35 +1,39 @@
-dep_libmediactl = cc.find_library('libmediactl',required : true, dirs: meson.current_source_dir())
-dep_libv4l2subdev = cc.find_library('libv4l2subdev',required : true, dirs: meson.current_source_dir())
+if get_option('dma_test')
+	user_hint = 'If you rather not build this, set "dma_test=false".'
 
-dep_dma_test = [
-	dep_libdrm,
-	dep_libmediactl,
-	dep_libv4l2subdev,
-	dep_wayland_client,
-	dependency('threads'),
-	dependency('libudev', version: '>= 136'),
-]
+	dep_libmediactl = cc.find_library('libmediactl',required : true, dirs: meson.current_source_dir())
+	dep_libv4l2subdev = cc.find_library('libv4l2subdev',required : true, dirs: meson.current_source_dir())
 
-foreach depname : [ 'egl', 'wayland-egl', 'glesv2', 'libdrm_intel' ]
-	dep = dependency(depname, required: false)
-	if not dep.found()
-		error('@0@ requires @1@ which was not found.')
-	endif
-	dep_dma_test += dep
-endforeach
+	dep_dma_test = [
+		dep_libdrm,
+		dep_libmediactl,
+		dep_libv4l2subdev,
+		dep_wayland_client,
+		dependency('threads'),
+		dependency('libudev', version: '>= 136'),
+	]
 
-executable(
-	'dma_test',
-	'dma_test.c',
-	'mediactl.h',
-	'v4l2subdev.h',
-	ias_shell_protocol_c,
-	ias_shell_client_protocol_h,
-	ivi_application_protocol_c,	
-	ivi_application_client_protocol_h,
-	'../cmn/wayland-drm-protocol.c',
-	include_directories: include_directories('.','../..','../wl_base','../wl_disp','../../shared', '../cmn'),
-	dependencies: dep_dma_test,
-	install: true,
-	install_dir: join_paths(dir_data, 'ias/examples')
-)
+	foreach depname : [ 'egl', 'wayland-egl', 'glesv2', 'libdrm_intel' ]
+		dep = dependency(depname, required: false)
+		if not dep.found()
+			error('@0@ requires @1@ which was not found.' + user_hint)
+		endif
+		dep_dma_test += dep
+	endforeach
+
+	executable(
+		'dma_test',
+		'dma_test.c',
+		'mediactl.h',
+		'v4l2subdev.h',
+		ias_shell_protocol_c,
+		ias_shell_client_protocol_h,
+		ivi_application_protocol_c,	
+		ivi_application_client_protocol_h,
+		'../cmn/wayland-drm-protocol.c',
+		include_directories: include_directories('.','../..','../wl_base','../wl_disp','../../shared', '../cmn'),
+		dependencies: dep_dma_test,
+		install: true,
+		install_dir: join_paths(dir_data, 'ias/examples')
+	)
+endif

--- a/clients/dma_test/readme.txt
+++ b/clients/dma_test/readme.txt
@@ -74,15 +74,15 @@ Running Instructions:
 Examples:
 
 To run HDMI:
-dma_test -d /dev/video16 -n 0 -I 1920,1080 -O 1920,1080 -b 3 -f RGB3 -r GL_DMA -E
+dma_test -d /dev/video16 -n 0 -I 1920,1080 -O 1920,1080 -b 3 -f RGB3 -r GL_DMA 
 
 To run camera:
-dma_test -d /dev/video16 -i -n 4 -I 720,480 -O 1920,1080 -b 3 -f UYVY -r GL_DMA -E 
+dma_test -d /dev/video16 -i -n 4 -I 720,480 -O 1920,1080 -b 3 -f UYVY -r GL_DMA 
 
 
 Example of output:
 
-dma_test -d /dev/video16 -n 0 -I 1920,1080 -O 1920,1080 -b 3 -f RGB3 -r GL_DMA -E
+dma_test -d /dev/video16 -n 0 -I 1920,1080 -O 1920,1080 -b 3 -f RGB3 -r GL_DMA 
 G_FMT(start): width = 1920, height = 1080, 4cc = XR24
 G_FMT(final): width = 1920, height = 1080, 4cc = XR24
 DMA TEST TIME STATS

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -147,6 +147,13 @@ option(
 )
 
 option(
+	'dma_test',
+	type: 'boolean',
+	value: false,
+	description: 'An app to display IPU content on screen through dma_buf'
+)
+
+option(
 	'color-management-lcms',
 	type: 'boolean',
 	value: true,


### PR DESCRIPTION
dma_test will not be build by default, meson option have to be
specified like this to enable it:
meson builddir/ -D<option_name>=<boolean>
For example: meson builddir/ -Ddma_test=true

During execution, -E flag is being used, dma_test tool will be using dma buffer
exported from the IPU driver instead of GPU driver, and the
performance is not as optimized in that case. Higher CPU load has
been observed.