### PR TITLE
FIX: klockworks issues

### DIFF
--- a/clients/RemoteDisplay/input_receiver.c
+++ b/clients/RemoteDisplay/input_receiver.c
@@ -642,6 +642,11 @@ start_event_listener(struct app_state *appstate, int *argc, char **argv)
 
 	data = calloc(1, sizeof(*data));
 
+	if (data == NULL)
+	{
+	    INFO("Memory allocation failed...\n");
+	    return;
+	}
 	/* In case of udp transport, we should get the  */
 	if(!strcmp(appstate->transport_plugin, "udp") &&
 		appstate->get_sockaddr_fptr) {

--- a/clients/RemoteDisplay/transport_plugin_avb.c
+++ b/clients/RemoteDisplay/transport_plugin_avb.c
@@ -95,7 +95,8 @@ WL_EXPORT int init(int *argc, char **argv, int verbose)
 
 		if (tmp) {
 			unsigned int max_write = 0;
-			strncpy(tmp, private_data->packet_path, PATH_MAX);
+			strncpy(tmp, private_data->packet_path, PATH_MAX-1);
+			tmp[PATH_MAX-1] = '\0';
 			max_write = PATH_MAX - strlen(tmp) - 1;
 			strncat(tmp, "packets.rtp", max_write);
 		} else {

--- a/clients/RemoteDisplay/transport_plugin_file.c
+++ b/clients/RemoteDisplay/transport_plugin_file.c
@@ -150,7 +150,8 @@ WL_EXPORT int send_frame(drm_intel_bo *drm_bo, int32_t stream_size, uint32_t tim
 
 			last_char = private_data->file_path[(int)strlen(private_data->file_path)-1];
 
-			strncpy(filepath, private_data->file_path, PATH_MAX);
+			strncpy(filepath, private_data->file_path, PATH_MAX-1);
+			filepath[PATH_MAX-1] = '\0';
 
 			if (last_char != '/') {
 				/* Filename included in path */

--- a/clients/RemoteDisplay/transport_plugin_udp.c
+++ b/clients/RemoteDisplay/transport_plugin_udp.c
@@ -188,6 +188,17 @@ WL_EXPORT int init(int *argc, char **argv, int verbose)
 
 	if(!private_data->tp) {
 		private_data->tp = strdup("native");
+		if (private_data->tp == NULL){
+		   ERROR("strdup() failed...\n");
+		   if(private_data->ipaddr) {
+			free(private_data->ipaddr);
+		   }
+		   if(private_data->tp) {
+			free(private_data->tp);
+		   }
+		   free(private_data);
+		   return -1;
+		}
 	}
 
 	strcpy(copy, private_data->ipaddr);
@@ -685,7 +696,7 @@ static int send_frame_native(drm_intel_bo *drm_bo, int32_t stream_size, uint32_t
 			rd=read(private_data->fifo_handle, buffer, 255);
 			if(rd>0) {
 				char *arg = NULL;
-				buffer[rd] = 0;
+				buffer[rd-1] = 0;
 				char *ptr = buffer;
 				while (*ptr) {
 					if (*ptr == '\n') {

--- a/clients/content_protection.c
+++ b/clients/content_protection.c
@@ -336,6 +336,7 @@ int main(int argc, char *argv[])
 	d = display_create(&argc, argv);
 	if (d == NULL) {
 		fprintf(stderr, "failed to create display: %m\n");
+		free(pc_player);
 		return -1;
 	}
 	pc_player->protection_type = WESTON_PROTECTED_SURFACE_TYPE_UNPROTECTED;

--- a/clients/dma_test/dma_test.c
+++ b/clients/dma_test/dma_test.c
@@ -1920,6 +1920,10 @@ init_gl_shaders(struct window *window)
 
 			if (color_format == window->display->s->in_fourcc) {
 				shader_binary = malloc(shader_size);
+				if (shader_binary == NULL)
+				{
+				    BYE_ON(pf, "Failed to allocate memory for shader_binary\n");
+				}
 
 				size_t result_ss = fread(shader_binary, shader_size, 1, pf);
 				if(result_ss != 1) {
@@ -2238,7 +2242,8 @@ main(int argc, char **argv)
 
 	ret = init_gem(&display);
 	if(ret < 0) {
-		return ret;
+	    close(v4l2.fd);
+	    return ret;
 	}
 
 	for(i = 0; i < (int) s.buffer_count; i++) {
@@ -2246,12 +2251,16 @@ main(int argc, char **argv)
 			v4l2_expbuffer(&v4l2, i, &buffers[i]);
 			ret = drm_buffer_to_prime(&display, &buffers[i], src_size);
 			if(ret < 0) {
-				return ret;
+			    destroy_gem(&display);
+			    close(v4l2.fd);
+			    return ret;
+
 			}
 		} else {
 			ret = create_buffer(&display, &buffers[i], src_size);
 			if(ret < 0) {
 				destroy_gem(&display);
+				close(v4l2.fd);
 				return ret;
 			}
 		}

--- a/clients/eglinfo.c
+++ b/clients/eglinfo.c
@@ -207,6 +207,11 @@ main(int argc, char *argv[])
 
 	configs = calloc(count, sizeof *configs);
 
+	if (configs == NULL)
+	{
+	    printf("Memory allocation failed ... \n");
+	    return 1;
+	}
 	eglChooseConfig(d, config_attribs,
 			      configs, count, &n);
 

--- a/clients/vmdisplay/vmdisplay-input.cpp
+++ b/clients/vmdisplay/vmdisplay-input.cpp
@@ -591,4 +591,6 @@ int main(int argc, char *argv[])
 
 	server.run();
 	server.cleanup();
+
+	return 0;
 }

--- a/clients/vmdisplay/vmdisplay-server-network.cpp
+++ b/clients/vmdisplay/vmdisplay-server-network.cpp
@@ -67,6 +67,7 @@ int NetworkCommunicator::init(int domid, HyperCommunicatorDirection dir,
 
 	UNUSED(domid);
 	strncpy(args_tmp, args, 254);
+	args_tmp[sizeof(args_tmp)-1] = '\0';
 
 	addr = strtok(args_tmp, ":");
 	if (!addr) {

--- a/clients/vmdisplay/vmdisplay.c
+++ b/clients/vmdisplay/vmdisplay.c
@@ -284,7 +284,7 @@ int check_for_new_buffer(void)
 
 static void create_new_buffer_common(int dmabuf_fd)
 {
-	GLuint textureId[2];
+	GLuint textureId[2] = {0};
 	struct zwp_linux_buffer_params_v1 *params;
 	int i;
 
@@ -665,7 +665,11 @@ int vmdisplay_socket_init(vmdisplay_socket * vmsocket, int domid)
 		return -1;
 	}
 
-	recv(vmsocket->socket_fd, &msg, sizeof(msg), 0);
+	if(recv(vmsocket->socket_fd, &msg, sizeof(msg), 0) < 0)
+	{
+	    perror("Recieve error\n");
+	    return -1;
+	}
 	for (i = 0; i < msg.display_num; i++) {
 		vmsocket->outputs[i].mem_fd = recvfd(vmsocket->socket_fd);
 		vmsocket->outputs[i].mem_addr =

--- a/ias-shell/ias-hmi.c
+++ b/ias-shell/ias-hmi.c
@@ -524,6 +524,11 @@ ias_hmi_client_created(struct wl_client *client,
 {
 	struct ias_shell *shell = shell_resource->data;
 	struct soc_node *node = calloc(1, sizeof(struct soc_node));
+	if (node == NULL)
+	{
+		printf("soc_node memory allocation is failed...\n");
+		return;
+	}
 	node->pid = pid;
 	node->soc = soc;
 	wl_list_insert(&shell->soc_list, &node->link);

--- a/ias-shell/ias-shell.c
+++ b/ias-shell/ias-shell.c
@@ -1486,6 +1486,11 @@ ias_surface_constructor(void *shellptr,
 
 	wl_list_for_each(output, &surface->compositor->output_list, link) {
 		fd = calloc(1, sizeof *fd);
+		if (fd == NULL)
+		{
+		    IAS_ERROR("Failed to allocate memory for frame data");
+		    return NULL;
+		}
 		fd->output_id = output->id;
 		wl_list_init(&fd->output_link);
 		wl_list_insert(&shsurf->output_list, &fd->output_link);

--- a/libweston/backend-ias/ias.c
+++ b/libweston/backend-ias/ias.c
@@ -4033,6 +4033,11 @@ start_capture(struct wl_client *client,
 		surface->keep_buffer = 1;
 
 		capture_proxy_item = calloc(1, sizeof(struct ias_surface_capture));
+		if (!capture_proxy_item)
+		{
+		    weston_log("Failed to allocate the memory for capture proxy item\n");
+		    return IAS_HMI_FCAP_ERROR_INVALID;
+		}
 		capture_proxy_item->backend = ias_backend;
 		capture_proxy_item->capture_surface = surface;
 		capture_proxy_item->cp =

--- a/tests/ivi-layout-test-plugin.c
+++ b/tests/ivi-layout-test-plugin.c
@@ -243,6 +243,7 @@ wet_module_init(struct weston_compositor *compositor,
 					launcher->exe,
 					sizeof launcher->exe) == 0) {
 		weston_log("test setup failure: WESTON_MODULE_MAP not set\n");
+		free(launcher);
 		return -1;
 	}
 


### PR DESCRIPTION
Klocworks issues were fixed on the weston-7.0.4,
below are the files modified.
clients/RemoteDisplay/input_receiver.c
clients/RemoteDisplay/transport_plugin_avb.c
clients/RemoteDisplay/transport_plugin_file.c
clients/RemoteDisplay/transport_plugin_udp.c
clients/content_protection.c
clients/dma_test/dma_test.c
clients/eglinfo.c
clients/vmdisplay/vmdisplay-input.cpp
clients/vmdisplay/vmdisplay-server-network.cpp
clients/vmdisplay/vmdisplay.c
ias-shell/ias-hmi.c
ias-shell/ias-shell.c
libweston/backend-ias/ias.c
tests/ivi-layout-test-plugin.c