### PR TITLE
Set presetation clock while initialising the IAS compositor

### DIFF
--- a/libweston/backend-ias/ias.c
+++ b/libweston/backend-ias/ias.c
@@ -4281,6 +4281,11 @@ init_drm(struct ias_backend *backend, struct udev_device *device)
 	else
 		backend->clock = CLOCK_REALTIME;
 
+	if (weston_compositor_set_presentation_clock(backend->compositor, backend->clock) < 0) {
+		weston_log("Error: failed to set presentation clock %d.\n", backend->clock);
+		return -1;
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
The presentation clock for the compositor is set by weston_compositor_set_presentation_clock.
This method was missing from ias.c, thus the presentation_clock remained with the default value (0),
which is defined as CLOCK_REALTIME in time.h.

If the presentation_clock is CLOCK_REALTIME and the user changes the date continuously the image will shatter or will freeze.
In this case CLOCK_MONOTONIC is preferred.